### PR TITLE
feat: 配置 npm 全局安装支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,15 @@
 
 ### 安装
 
-#### 方式一：NPM 全局安装（暂未支持）
+#### 方式一：NPM 全局安装（推荐）
 
+```bash
+# 全局安装
+npm install -g tiangong-cli
+
+# 启动
+tiangong-cli
+```
 
 #### 方式二：源码安装
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -51,8 +51,15 @@
 
 ### Installation
 
-#### Method 1: NPM Global Install (Not Yet Supported)
+#### Method 1: NPM Global Install (Recommended)
 
+```bash
+# Global install
+npm install -g tiangong-cli
+
+# Start
+tiangong-cli
+```
 
 #### Method 2: Install from Source
 

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -47,7 +47,7 @@ const cliConfig = {
     js: `import { createRequire } from 'module'; const require = createRequire(import.meta.url); globalThis.__filename = require('url').fileURLToPath(import.meta.url); globalThis.__dirname = require('path').dirname(globalThis.__filename);`,
   },
   entryPoints: ['packages/cli/index.ts'],
-  outfile: 'bundle/gemini.js',
+  outfile: 'bundle/tiangong-cli.js',
   define: {
     'process.env.CLI_VERSION': JSON.stringify(pkg.version),
   },
@@ -79,10 +79,10 @@ Promise.allSettled([
 ]).then((results) => {
   const [cliResult, a2aResult] = results;
   if (cliResult.status === 'rejected') {
-    console.error('gemini.js build failed:', cliResult.reason);
+    console.error('tiangong-cli.js build failed:', cliResult.reason);
     process.exit(1);
   }
-  // error in a2a-server bundling will not stop gemini.js bundling process
+  // error in a2a-server bundling will not stop tiangong-cli.js bundling process
   if (a2aResult.status === 'rejected') {
     console.warn('a2a-server build failed:', a2aResult.reason);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
-  "name": "@google/gemini-cli",
-  "version": "0.6.0-nightly",
+  "name": "tiangong-cli",
+  "version": "0.1.1",
+  "description": "TianGong CLI - Enhanced AI command-line tool with custom models, agents system, and workflow orchestration",
+  "keywords": ["ai", "cli", "gemini", "agent", "workflow", "qwen", "deepseek", "tiangong"],
+  "author": "mj-cjm <japycjm@gmail.com>",
+  "license": "Apache-2.0",
   "engines": {
     "node": ">=20.0.0"
   },
@@ -8,10 +12,10 @@
   "workspaces": [
     "packages/*"
   ],
-  "private": "true",
+  "private": false,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/google-gemini/gemini-cli.git"
+    "url": "git+https://github.com/MJ-CJM/tiangong-cli.git"
   },
   "config": {
     "sandboxImageUri": "us-docker.pkg.dev/gemini-code-dev/gemini-cli/sandbox:0.6.0-nightly"
@@ -55,7 +59,7 @@
     "pre-commit": "node scripts/pre-commit.js"
   },
   "bin": {
-    "gemini": "bundle/gemini.js"
+    "tiangong-cli": "bundle/tiangong-cli.js"
   },
   "files": [
     "bundle/",


### PR DESCRIPTION
npm 包配置 (package.json):
- 包名: @google/gemini-cli → tiangong-cli
- 版本: 0.6.0-nightly → 0.1.1
- private: true → false (允许发布)
- bin: gemini → tiangong-cli (全局命令名)
- 构建文件: bundle/gemini.js → bundle/tiangong-cli.js
- repository: 更新为 MJ-CJM/tiangong-cli
- 新增字段:
  * description: TianGong CLI 功能描述
  * keywords: ai, cli, gemini, agent, workflow, qwen, deepseek, tiangong
  * author: mj-cjm <japycjm@gmail.com>
  * license: Apache-2.0

构建配置 (esbuild.config.js):
- outfile: bundle/gemini.js → bundle/tiangong-cli.js
- 错误信息中的文件名同步更新

文档更新:
- README.md: 更新安装方式为 npm install -g tiangong-cli
- README_EN.md: 同步更新英文版本
- 标注为推荐安装方式

使用方法:
```bash
# 全局安装
npm install -g tiangong-cli

# 启动使用
tiangong-cli
```

发布状态:
- ✅ 已发布到 npm: v0.1.1
- ✅ 包页面: https://www.npmjs.com/package/tiangong-cli
- ✅ 全局命令: tiangong-cli

清理:
- 删除旧的 bundle/gemini.js 文件
