### PR TITLE
feat: 添加 Plan+Todo 模式及文档整理

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -52,7 +52,14 @@
   - [README.md](./workflows/README.md) - Workflow 系统概述
   - [design.md](./workflows/design.md) - Workflow 架构设计
 
-### 4️⃣ 模式切换系统（计划中）
+### 4️⃣ Plan+Todo 模式
+- **[plan-todo/](./plan-todo/)** - Plan+Todo 模式
+  - [README.md](./plan-todo/README.md) - Plan+Todo 系统概述
+  - [DESIGN_AND_IMPLEMENTATION.md](./plan-todo/DESIGN_AND_IMPLEMENTATION.md) - 设计与实现
+  - [API.md](./plan-todo/API.md) - 命令和工具 API
+  - [USER_GUIDE.md](./plan-todo/USER_GUIDE.md) - 用户指南
+
+### 5️⃣ 模式切换系统（计划中）
 - **[modes/](./modes/)** - 模式切换
   - _功能规划中，文档待创建_
 
@@ -66,6 +73,7 @@
 - [Agents 快速开始](./agents/QUICK_START.md)
 - [添加新模型指南](./models/add-new-model-guide.md)
 - [Workflow 系统概述](./workflows/README.md)
+- [Plan+Todo 用户指南](./plan-todo/USER_GUIDE.md)
 
 #### 👨‍💻 开发者文档
 - [系统架构](./architecture.md)
@@ -73,12 +81,14 @@
 - [Agents 实现细节](./agents/IMPLEMENTATION.md)
 - [模型支持设计](./models/universal-model-support.md)
 - [Workflow 设计](./workflows/design.md)
+- [Plan+Todo 设计与实现](./plan-todo/DESIGN_AND_IMPLEMENTATION.md)
 
 #### 🔧 功能参考
 - [Agents 命令参考](./agents/COMMANDS.md)
 - [路由功能](./agents/routing/README.md)
 - [移交功能](./agents/handoff/README.md)
 - [上下文管理](./agents/context/README.md)
+- [Plan+Todo API 参考](./plan-todo/API.md)
 
 ### 按功能导航
 
@@ -106,6 +116,13 @@
 - **用户指南**: [workflows/user-guide.md](./workflows/user-guide.md)
 - **状态**: ✅ 已完成（含并行执行）
 
+#### 📋 Plan+Todo 模式
+- **概述**: [plan-todo/README.md](./plan-todo/README.md)
+- **设计与实现**: [plan-todo/DESIGN_AND_IMPLEMENTATION.md](./plan-todo/DESIGN_AND_IMPLEMENTATION.md)
+- **API 参考**: [plan-todo/API.md](./plan-todo/API.md)
+- **用户指南**: [plan-todo/USER_GUIDE.md](./plan-todo/USER_GUIDE.md)
+- **状态**: ✅ 已完成（含批量执行）
+
 #### 🎯 模式切换（计划中）
 - **概述**: 📋 规划中
 - **状态**: 📋 设计阶段
@@ -124,6 +141,8 @@
 | **交互式创建** | 100% | ✅ 已完成 | 100% |
 | **Workflow 顺序** | 100% | ✅ 已完成 | 100% |
 | **Workflow 并行** | 100% | ✅ 已完成 | 100% |
+| **Plan+Todo 模式** | 100% | ✅ 已完成 | 100% |
+| **批量执行** | 100% | ✅ 已完成 | 100% |
 | **模式切换** | 0% | 📋 计划中 | 0% |
 
 ---
@@ -152,6 +171,7 @@
 ### 📚 用户文档
 - [完整用户指南](../docs/AGENTS.md)
 - [Workflow 使用指南](../docs/WORKFLOWS.md)
+- [Plan+Todo 模式用户手册](../docs/PLAN_TODO_MODE_USER_GUIDE.md)
 - [添加新模型](../docs/ADD_NEW_MODEL.md)
 
 ### 💻 代码实现
@@ -173,6 +193,7 @@
 
 ### 更新记录
 
+- **2025-10-16**: Plan+Todo 模式完成，文档整理
 - **2025-10-14**: 重组文档结构，按功能分层管理
 - **2025-10-13**: Workflow 并行功能完成，文档更新
 - **2025-10-07**: Agents P2 功能完成

--- a/design/plan-todo/API.md
+++ b/design/plan-todo/API.md
@@ -1,0 +1,589 @@
+# Plan+Todo 模式 - API 参考
+
+> 完整的命令和工具 API 参考
+
+---
+
+## 📋 目录
+
+- [快捷键](#快捷键)
+- [Slash 命令](#slash-命令)
+- [工具 API](#工具-api)
+- [类型定义](#类型定义)
+
+---
+
+## 快捷键
+
+| 快捷键 | 功能 | 说明 |
+|--------|------|------|
+| `Ctrl+P` | 切换 Plan 模式 | 进入/退出 Plan 模式 |
+| `Ctrl+C` | 中断执行 | 停止当前任务或批量执行 |
+
+---
+
+## Slash 命令
+
+### /plan 命令组
+
+#### /plan show
+
+**功能**: 显示当前计划的详细内容
+
+**语法**:
+```bash
+/plan show
+```
+
+**输出示例**:
+```markdown
+# 📋 Implement User Login
+
+**Overview**: Add JWT-based authentication...
+
+## 🔢 Steps (5)
+
+1. **step-1**: Create User model
+   - 📦 Module: backend/models
+   - ⏱️  Estimated: 30min
+
+...
+```
+
+---
+
+#### /plan to-todos
+
+**功能**: 将当前计划转换为可执行的 todo 列表
+
+**语法**:
+```bash
+/plan to-todos
+```
+
+**效果**:
+- 创建 todos（内存存储）
+- 自动分配优先级
+- 保留依赖关系
+
+**输出示例**:
+```
+✅ Created 5 todos from plan "Implement User Login"
+
+💡 Next steps:
+- /todos list - View all todos
+- /todos execute <id> - Execute a todo
+```
+
+**注意**:
+- ⚠️ 会覆盖已存在的 todos
+- ⚠️ 内存存储，会话结束后清空
+
+---
+
+#### /plan clear
+
+**功能**: 清除当前计划
+
+**语法**:
+```bash
+/plan clear
+```
+
+**效果**:
+- 删除当前 plan 数据
+- 不影响已创建的 todos
+
+---
+
+### /todos 命令组
+
+#### /todos list
+
+**功能**: 显示所有 todo 列表
+
+**语法**:
+```bash
+/todos list
+```
+
+**显示内容**:
+- 统计信息（总数、各状态数量）
+- 按优先级分组的活跃任务
+- 已完成和已取消的任务
+
+**输出示例**:
+```
+📋 Todo List (5 total)
+
+✅ 2 completed | 🔄 1 in progress | ⬜ 2 pending | ❌ 0 cancelled
+
+### HIGH Priority
+
+⬜ step-1 - Create User model ⏱️ 30min
+   📦 Module: backend/models
+
+⬜ step-2 - Implement JWT ⏱️ 45min
+   📦 Module: backend/auth
+   🔗 Dependencies: step-1
+   ⚠️  Token security vulnerabilities
+```
+
+---
+
+#### /todos execute
+
+**功能**: 执行指定的 todo
+
+**语法**:
+```bash
+/todos execute <id> [--mode=auto_edit|default]
+```
+
+**参数**:
+- `<id>`: 必需，todo 的 ID（如 `step-1`）
+- `--mode`: 可选，执行模式
+  - `default`: 默认模式，需要确认（默认值）
+  - `auto_edit`: 自动模式，自动批准
+
+**示例**:
+```bash
+# 使用默认模式
+/todos execute step-1
+
+# 使用自动模式
+/todos execute step-1 --mode=auto_edit
+
+# 明确指定默认模式
+/todos execute step-1 --mode=default
+```
+
+**执行流程**:
+1. 检查依赖是否完成
+2. 设置执行模式
+3. 显示任务信息
+4. 开始执行
+5. 提示更新状态
+
+**依赖检查示例**:
+```bash
+> /todos execute step-3
+
+❌ Cannot execute step-3. Dependencies not completed:
+- step-1
+- step-2
+
+Complete dependencies first.
+```
+
+---
+
+#### /todos execute-all
+
+**功能**: 批量执行所有待执行的 todos
+
+**语法**:
+```bash
+/todos execute-all [--mode=auto_edit|default]
+```
+
+**参数**:
+- `--mode`: 可选，执行模式
+  - `default`: 默认模式，需要确认（默认值）
+  - `auto_edit`: 自动模式，自动批准所有操作
+
+**特性**:
+- 🔄 自动按顺序执行所有待执行 todos
+- 🔗 自动检查依赖关系
+- 📊 实时显示进度
+- ⏸️ Ctrl+C 随时中断
+- 🛡️ 错误自动恢复
+
+**示例 1 - Default 模式**:
+```bash
+> /todos execute-all --mode=default
+
+🚀 Starting Batch Execution
+
+📊 Total todos: 5
+⚙️ Approval mode: default
+🎯 First todo: Create User model
+
+---
+
+▶️  [1/5] Create User model ⏱️ 30min
+
+⚠️ write_file backend/models/User.ts
+Confirm? (y/n): y
+✓ write_file backend/models/User.ts
+
+✅ Task 1 completed
+
+---
+
+▶️  [2/5] Implement JWT ⏱️ 45min
+[...]
+
+---
+
+✅ Batch Execution Complete!
+📊 Executed 5/5 todos
+```
+
+**示例 2 - Auto-edit 模式**:
+```bash
+> /todos execute-all --mode=auto_edit
+
+🚀 Starting Batch Execution
+
+📊 Total todos: 5
+⚙️ Approval mode: auto_edit
+
+---
+
+▶️  [1/5] Create User model ⏱️ 30min
+✓ write_file backend/models/User.ts (auto-approved)
+
+▶️  [2/5] Implement JWT ⏱️ 45min
+✓ write_file backend/auth/jwt.ts (auto-approved)
+
+[...]
+
+✅ Batch Execution Complete!
+📊 Executed 5/5 todos in 2.5 minutes
+```
+
+**中断执行**:
+```bash
+> /todos execute-all --mode=auto_edit
+
+▶️  [2/5] Implement JWT...
+
+^C  ← 按 Ctrl+C
+
+⏸️  Batch Execution Interrupted
+Completed: 1/5 todos
+
+Use /todos list to see current progress
+Use /todos execute-all to resume
+```
+
+**错误处理**:
+```bash
+> /todos execute-all
+
+▶️  [3/5] Create API endpoints...
+
+❌ Error: File already exists
+
+❌ Batch Execution Failed
+Todo 3/5 encountered an error.
+Progress: 2 completed, 1 failed
+
+💡 Fix the issue and run /todos execute-all to continue
+```
+
+**适用场景**:
+- ✅ 信任的任务列表（auto_edit）
+- ✅ 简单的批量操作
+- ✅ 测试或文档任务
+- ⚠️ 不适合核心业务逻辑
+
+**注意事项**:
+- 按顺序执行所有 `pending` 状态的 todos
+- 跳过 `completed` 或 `cancelled` 的 todos
+- 自动检查依赖关系
+- 中断后可随时恢复
+
+---
+
+#### /todos update
+
+**功能**: 更新 todo 的状态
+
+**语法**:
+```bash
+/todos update <id> <status>
+```
+
+**参数**:
+- `<id>`: todo 的 ID
+- `<status>`: 新状态
+  - `pending`: 待执行
+  - `in_progress`: 执行中
+  - `completed`: 已完成
+  - `cancelled`: 已取消
+
+**示例**:
+```bash
+# 标记为已完成
+/todos update step-1 completed
+
+# 标记为取消
+/todos update step-5 cancelled
+
+# 重置为待执行
+/todos update step-2 pending
+```
+
+**输出示例**:
+```
+✅ Updated step-1 → completed
+
+📋 Current progress:
+✅ 1 completed | 🔄 0 in progress | ⬜ 4 pending
+```
+
+---
+
+#### /todos export
+
+**功能**: 导出 todos 为 JSON 格式
+
+**语法**:
+```bash
+/todos export
+```
+
+**输出格式**:
+```json
+{
+  "version": "1.0",
+  "generatedAt": "2025-10-16T12:00:00.000Z",
+  "sourcePlan": "Plan title",
+  "todos": [
+    {
+      "id": "step-1",
+      "description": "Create User model",
+      "status": "completed",
+      "priority": "high",
+      "module": "backend/models",
+      "dependencies": [],
+      "risks": ["Data validation"],
+      "estimatedTime": "30min",
+      "createdFrom": "plan",
+      "createdAt": "2025-10-16T11:00:00.000Z",
+      "completedAt": "2025-10-16T11:25:00.000Z"
+    }
+  ],
+  "statistics": {
+    "total": 5,
+    "pending": 1,
+    "in_progress": 0,
+    "completed": 3,
+    "cancelled": 1
+  }
+}
+```
+
+**用途**:
+- 📊 进度报告
+- 🔄 外部工具集成
+- 📝 项目文档
+- 💾 备份记录
+
+---
+
+#### /todos clear
+
+**功能**: 清除所有 todos
+
+**语法**:
+```bash
+/todos clear
+```
+
+**效果**:
+- 删除内存中的所有 todos
+- 不影响 plan 数据
+
+---
+
+## 工具 API
+
+### create_plan
+
+**工具名称**: `create_plan`
+
+**描述**: 创建结构化的执行计划
+
+**参数类型**:
+```typescript
+interface PlanToolParams {
+  title: string;              // 计划标题（必需）
+  overview: string;           // 计划概述（必需）
+  steps: PlanStep[];          // 执行步骤（必需）
+  risks?: string[];           // 整体风险（可选）
+  testingStrategy?: string;   // 测试策略（可选）
+  estimatedDuration?: string; // 总体时间估计（可选）
+}
+
+interface PlanStep {
+  id: string;                 // 步骤 ID（必需）
+  description: string;        // 步骤描述（必需）
+  module?: string;            // 模块名称（可选）
+  dependencies?: string[];    // 依赖的步骤 ID（可选）
+  risks?: string[];           // 步骤风险（可选）
+  estimatedTime?: string;     // 时间估计（可选）
+}
+```
+
+**返回值**:
+```typescript
+interface ToolResult {
+  success: boolean;
+  message: string;
+  data?: PlanToolParams;
+}
+```
+
+**使用示例** (AI 调用):
+```json
+{
+  "tool": "create_plan",
+  "parameters": {
+    "title": "Implement User Login",
+    "overview": "Add JWT-based authentication",
+    "steps": [
+      {
+        "id": "step-1",
+        "description": "Create User model",
+        "module": "backend/models",
+        "estimatedTime": "30min"
+      },
+      {
+        "id": "step-2",
+        "description": "Implement JWT",
+        "module": "backend/auth",
+        "dependencies": ["step-1"],
+        "risks": ["Token security"],
+        "estimatedTime": "45min"
+      }
+    ],
+    "risks": ["Session management complexity"],
+    "testingStrategy": "Unit tests + Integration tests"
+  }
+}
+```
+
+**验证规则**:
+- `title`: 非空字符串
+- `overview`: 非空字符串
+- `steps`: 至少包含 1 个步骤
+- 每个步骤必须有唯一的 `id`
+- `dependencies` 必须引用已存在的步骤 ID
+
+---
+
+### write_todos
+
+**工具名称**: `write_todos`
+
+**描述**: 创建或更新 todo 列表
+
+**参数类型**:
+```typescript
+interface ExtendedTodo {
+  id: string;                       // Todo ID（必需）
+  description: string;              // 描述（必需）
+  status: TodoStatus;               // 状态（必需）
+  priority?: 'high' | 'medium' | 'low';
+  module?: string;
+  dependencies?: string[];
+  risks?: string[];
+  estimatedTime?: string;
+  createdFrom?: 'plan' | 'manual';
+  createdAt?: string;
+  completedAt?: string;
+}
+
+type TodoStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled';
+```
+
+**注意**: 用户通常不直接调用此工具，而是通过 `/plan to-todos` 自动创建
+
+---
+
+## 类型定义
+
+### PlanData
+
+```typescript
+interface PlanData {
+  title: string;
+  overview: string;
+  steps: PlanStep[];
+  risks?: string[];
+  testingStrategy?: string;
+  estimatedDuration?: string;
+}
+```
+
+### ExtendedTodo
+
+```typescript
+interface ExtendedTodo extends Todo {
+  id: string;
+  description: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'cancelled';
+  priority?: 'high' | 'medium' | 'low';
+  module?: string;
+  dependencies?: string[];
+  risks?: string[];
+  estimatedTime?: string;
+  createdFrom?: 'plan' | 'manual';
+  createdAt?: string;
+  completedAt?: string;
+}
+```
+
+### ExecutionQueue
+
+```typescript
+interface ExecutionQueue {
+  active: boolean;         // 是否正在批量执行
+  mode: 'default' | 'auto_edit'; // 执行模式
+  currentIndex: number;    // 当前执行索引
+  totalCount: number;      // 总 todo 数量
+  executingTodoId?: string; // 当前执行的 todo ID
+}
+```
+
+---
+
+## 命令速查表
+
+### 基本操作
+
+| 操作 | 命令/快捷键 |
+|------|------------|
+| 进入 Plan 模式 | `Ctrl+P` |
+| 退出 Plan 模式 | `Ctrl+P` |
+| 取消当前操作 | `Ctrl+C` |
+
+### Plan 命令
+
+| 命令 | 说明 |
+|------|------|
+| `/plan show` | 显示当前计划 |
+| `/plan to-todos` | 转换为 todos |
+| `/plan clear` | 清除计划 |
+
+### Todo 命令
+
+| 命令 | 说明 |
+|------|------|
+| `/todos list` | 列出所有 todos |
+| `/todos execute <id>` | 执行单个 todo（default 模式） |
+| `/todos execute <id> --mode=auto_edit` | 执行单个 todo（auto-edit 模式） |
+| `/todos execute-all` | 批量执行（default 模式） |
+| `/todos execute-all --mode=auto_edit` | 批量执行（auto-edit 模式） |
+| `/todos update <id> <status>` | 更新 todo 状态 |
+| `/todos export` | 导出为 JSON |
+| `/todos clear` | 清除所有 todos |
+
+---
+
+**最后更新**: 2025-10-16  
+**版本**: 1.0.0
+

--- a/design/plan-todo/DESIGN_AND_IMPLEMENTATION.md
+++ b/design/plan-todo/DESIGN_AND_IMPLEMENTATION.md
@@ -1,0 +1,718 @@
+# Plan+Todo 模式 - 设计与实现
+
+> 架构设计、核心组件、实现细节和关键修复
+
+---
+
+## 📋 目录
+
+- [架构设计](#架构设计)
+- [核心组件](#核心组件)
+- [状态管理](#状态管理)
+- [执行流程](#执行流程)
+- [批量执行机制](#批量执行机制)
+- [关键 Bug 修复](#关键-bug-修复)
+
+---
+
+## 架构设计
+
+### 整体架构
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                      AppContainer                        │
+│  ┌────────────────────────────────────────────────────┐ │
+│  │ State Management                                    │ │
+│  │ - planModeActive                                    │ │
+│  │ - currentPlan                                       │ │
+│  │ - todos                                             │ │
+│  │ - executionQueue                                    │ │
+│  └────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────┘
+           │                              │
+           ▼                              ▼
+┌──────────────────────┐      ┌──────────────────────┐
+│  useGeminiStream     │      │ slashCommandProcessor│
+│  - handleNextTodo    │      │ - planCommand        │
+│  - sendUserMessage   │      │ - todosCommand       │
+│  - Plan mode sync    │      │                      │
+└──────────────────────┘      └──────────────────────┘
+           │                              │
+           ▼                              ▼
+┌──────────────────────┐      ┌──────────────────────┐
+│  GeminiClient        │      │  TodoUtils           │
+│  - getPlanModeActive │      │  - formatTodosDisplay│
+│  - getUnifiedTools   │      │  - planToTodos       │
+│  - system prompt     │      │  - checkDependencies │
+└──────────────────────┘      └──────────────────────┘
+           │
+           ▼
+┌──────────────────────┐
+│  Core Tools          │
+│  - CreatePlanTool    │
+│  - WriteTodosTool    │
+└──────────────────────┘
+```
+
+### 核心设计原则
+
+1. **关注点分离**
+   - Core 层：工具定义和验证
+   - CLI 层：UI 逻辑和状态管理
+   - Command 层：用户交互和命令处理
+
+2. **状态管理**
+   - 内存存储：todos 和 plan 数据
+   - React hooks：响应式 UI 更新
+   - Refs 避免闭包陷阱
+
+3. **安全性**
+   - Plan 模式工具过滤
+   - 执行模式选择（default/auto_edit）
+   - 依赖关系验证
+
+---
+
+## 核心组件
+
+### 1. CreatePlanTool
+
+**文件**: `packages/core/src/tools/create-plan.ts`
+
+**职责**: 允许 AI 创建结构化计划
+
+**接口定义**:
+```typescript
+export interface PlanStep {
+  id: string;
+  description: string;
+  module?: string;
+  dependencies?: string[];
+  risks?: string[];
+  estimatedTime?: string;
+}
+
+export interface PlanToolParams {
+  title: string;
+  overview: string;
+  steps: PlanStep[];
+  risks?: string[];
+  testingStrategy?: string;
+  estimatedDuration?: string;
+}
+```
+
+**关键特性**:
+- 结构化输出（title, overview, steps, risks, testing）
+- 依赖关系验证
+- 参数验证（必填字段检查）
+
+---
+
+### 2. WriteTodosTool 扩展
+
+**文件**: `packages/core/src/tools/write-todos.ts`
+
+**ExtendedTodo 接口**:
+```typescript
+export interface ExtendedTodo extends Todo {
+  id: string;
+  priority?: 'high' | 'medium' | 'low';
+  module?: string;
+  dependencies?: string[];
+  risks?: string[];
+  estimatedTime?: string;
+  createdFrom?: 'plan' | 'manual';
+  createdAt?: string;
+  completedAt?: string;
+}
+```
+
+**新增字段**:
+- `priority`: 优先级自动分配（前 3 步为 high，4-6 为 medium，7+ 为 low）
+- `dependencies`: 依赖的 todo ID 列表
+- `risks`: 风险提示
+- `estimatedTime`: 预计完成时间
+
+---
+
+### 3. Plan 模式系统提示词
+
+**文件**: `packages/core/src/core/prompts.ts`
+
+**功能**: 在 Plan 模式下注入专用系统提示词
+
+**提示词结构**:
+```typescript
+export function getPlanModeSystemPrompt(): string {
+  return `
+# 🎯 PLAN MODE - Structured Planning Only
+
+You are in **PLAN MODE**. Your goal is to analyze requirements 
+and create detailed execution plans, NOT to execute them.
+
+## Constraints
+
+✅ **YOU CAN:**
+- Read files (read_file, read_many_files)
+- Search codebase (grep, rg, glob, ls)
+- Research information (web_search, web_fetch)
+- **Create structured plan (create_plan)** ⭐
+
+❌ **YOU CANNOT:**
+- Write or edit files (edit, write_file, smart_edit)
+- Execute commands (bash, shell)
+- Make any changes to the codebase
+
+## Your Workflow
+
+1. **Understand**: Read relevant files, search for patterns
+2. **Analyze**: Identify what needs to be done, dependencies, risks
+3. **Plan**: Call the \`create_plan\` tool with structured output
+`;
+}
+```
+
+---
+
+### 4. 工具过滤
+
+**文件**: `packages/core/src/core/client.ts`
+
+**实现**:
+```typescript
+getUnifiedTools(): UnifiedToolInfo[] {
+  const allTools = this.getAllTools();
+  
+  if (this.planModeActive) {
+    // Plan 模式：只允许只读工具 + create_plan
+    const READ_ONLY_TOOLS = [
+      'read_file', 'read_many_files', 'ls', 'glob', 
+      'grep', 'rg', 'web_fetch', 'web_search', 'create_plan'
+    ];
+    
+    return allTools.filter(tool => 
+      READ_ONLY_TOOLS.includes(tool.name)
+    );
+  }
+  
+  return allTools; // 普通模式：所有工具
+}
+```
+
+**效果**: Plan 模式下 AI 无法使用写工具
+
+---
+
+### 5. Slash 命令
+
+#### /plan 命令
+
+**文件**: `packages/cli/src/ui/commands/planCommand.ts`
+
+**子命令**:
+- `show`: 显示当前计划
+- `to-todos`: 将计划转换为 todos
+- `clear`: 清除计划
+
+**关键实现**:
+```typescript
+case 'to-todos': {
+  if (!session.currentPlan) {
+    return '❌ No active plan';
+  }
+  
+  const todos = planToTodos(session.currentPlan);
+  session.setTodos(todos);
+  
+  return `✅ Created ${todos.length} todos from plan "${plan.title}"`;
+}
+```
+
+#### /todos 命令
+
+**文件**: `packages/cli/src/ui/commands/todosCommand.ts`
+
+**子命令**:
+- `list`: 列出所有 todos
+- `execute <id> [--mode]`: 执行单个 todo
+- `execute-all [--mode]`: 批量执行所有 todos
+- `update <id> <status>`: 更新状态
+- `export`: 导出 JSON
+- `clear`: 清除所有
+
+---
+
+### 6. Todo 工具函数
+
+**文件**: `packages/cli/src/utils/todoUtils.ts`
+
+**核心函数**:
+
+```typescript
+// 格式化显示
+export function formatTodosDisplay(todos: ExtendedTodo[]): string
+
+// 计划转 todos
+export function planToTodos(plan: PlanData): ExtendedTodo[]
+
+// 检查依赖
+export function checkDependencies(
+  todo: ExtendedTodo, 
+  allTodos: ExtendedTodo[]
+): { satisfied: boolean; missing: string[] }
+
+// 获取下一个可执行 todo
+export function getNextExecutableTodo(
+  todos: ExtendedTodo[]
+): ExtendedTodo | null
+
+// 导出 JSON
+export function exportTodosToJson(
+  todos: ExtendedTodo[], 
+  sourcePlan?: PlanData
+): string
+```
+
+---
+
+## 状态管理
+
+### AppContainer 状态
+
+**文件**: `packages/cli/src/ui/AppContainer.tsx`
+
+```typescript
+// Plan 模式状态
+const [planModeActive, setPlanModeActive] = useState(false);
+const [currentPlan, setCurrentPlan] = useState<PlanData | null>(null);
+
+// Todo 列表（内存）
+const [todos, setTodos] = useState<ExtendedTodo[]>([]);
+
+// Todo 更新函数
+const updateTodo = useCallback((id: string, updates: Partial<ExtendedTodo>) => {
+  setTodos(prev => prev.map(t => 
+    t.id === id ? { ...t, ...updates } : t
+  ));
+}, []);
+
+// 批量执行队列
+const [executionQueue, setExecutionQueue] = useState<ExecutionQueue | null>(null);
+```
+
+### 状态传递
+
+**通过 session context**:
+```typescript
+const sessionContext = {
+  // ... 现有字段
+  todos,
+  setTodos,
+  updateTodo,
+  currentPlan,
+  setCurrentPlan,
+  planModeActive,
+  executionQueue,
+  setExecutionQueue,
+};
+```
+
+**传递到**:
+- `useSlashCommandProcessor`: 命令处理器
+- `useGeminiStream`: AI 交互管理
+
+---
+
+## 执行流程
+
+### Plan 模式流程
+
+```
+用户按 Ctrl+P
+    ↓
+setPlanModeActive(true)
+    ↓
+geminiClient.setPlanModeActive(true)
+    ↓
+提示符显示 [PLAN] >
+    ↓
+用户输入规划需求
+    ↓
+AI 调用 create_plan 工具
+    ↓
+setCurrentPlan(planData)
+    ↓
+显示计划内容
+    ↓
+用户按 Ctrl+P 退出
+    ↓
+setPlanModeActive(false)
+```
+
+### Todo 执行流程
+
+```
+用户: /plan to-todos
+    ↓
+planToTodos(currentPlan) → 创建 todos
+    ↓
+setTodos(newTodos)
+    ↓
+用户: /todos execute step-1 --mode=auto_edit
+    ↓
+检查依赖: checkDependencies(step-1, allTodos)
+    ↓
+设置审批模式: setApprovalMode(auto_edit)
+    ↓
+提交提示词: "Execute todo: step-1 ..."
+    ↓
+AI 执行任务
+    ↓
+用户: /todos update step-1 completed
+    ↓
+updateTodo('step-1', { status: 'completed' })
+```
+
+---
+
+## 批量执行机制
+
+### 架构
+
+```
+用户: /todos execute-all --mode=auto_edit
+    ↓
+todosCommand.ts (execute-all action)
+    ├─ 检查待执行 todos 数量
+    ├─ 找到第一个可执行 todo
+    ├─ 初始化 executionQueue 状态
+    ├─ 设置审批模式
+    └─ 提交执行提示词
+    ↓
+useGeminiStream.ts (sendUserMessage)
+    ├─ 处理 AI 响应
+    ├─ 执行工具调用
+    └─ finally { 触发 handleNextTodo }
+    ↓
+handleNextTodo()
+    ├─ 标记当前 todo 为 completed
+    ├─ 查找下一个可执行 todo
+    ├─ 更新 executionQueue
+    ├─ 显示进度
+    └─ 提交下一个 todo 执行提示词
+    ↓
+循环直到:
+    ├─ 所有 todos 完成 → 显示完成消息
+    ├─ 用户中断 (Ctrl+C) → 显示中断消息
+    └─ 发生错误 → 显示错误消息
+```
+
+### 关键实现
+
+**executionQueue 状态**:
+```typescript
+interface ExecutionQueue {
+  active: boolean;
+  mode: 'default' | 'auto_edit';
+  currentIndex: number;
+  totalCount: number;
+  executingTodoId?: string;
+}
+```
+
+**handleNextTodo 函数**:
+```typescript
+const handleNextTodo = useCallback(async () => {
+  const currentQueue = executionQueueRef.current;
+  if (!currentQueue?.active) return null;
+
+  // 1. 标记当前 todo 完成
+  if (currentQueue.executingTodoId) {
+    updateTodoRef.current(currentQueue.executingTodoId, {
+      status: 'completed',
+      completedAt: new Date().toISOString()
+    });
+  }
+
+  // 2. 查找下一个可执行 todo
+  const nextTodo = getNextExecutableTodo(todosRef.current);
+
+  if (!nextTodo) {
+    // 所有完成
+    setExecutionQueueRef.current(null);
+    return '✅ Batch Execution Complete!';
+  }
+
+  // 3. 更新队列状态
+  setExecutionQueueRef.current({
+    ...currentQueue,
+    currentIndex: currentQueue.currentIndex + 1,
+    executingTodoId: nextTodo.id
+  });
+
+  // 4. 返回下一个 todo 的提示词
+  return `[${currentQueue.currentIndex + 1}/${currentQueue.totalCount}] ${nextTodo.description}`;
+}, []);
+```
+
+**自动续接**:
+```typescript
+// useGeminiStream.ts - sendUserMessage 的 finally 块
+finally {
+  setIsResponding(false);
+  
+  // 检查批量执行队列
+  if (executionQueueRef.current?.active) {
+    setTimeout(async () => {
+      const nextPrompt = await handleNextTodo();
+      if (nextPrompt) {
+        // 自动提交下一个 todo
+        submitQueryRef.current(nextPrompt);
+      }
+    }, 500);
+  }
+}
+```
+
+---
+
+## 关键 Bug 修复
+
+### Bug 1: API 错误 - 孤儿 tool 响应
+
+**问题描述**:
+```
+API Error: messages with role "tool" must be a response 
+to a preceeding message with "tool_calls".
+```
+
+**根本原因**:
+- `APITranslator.validateAndFixToolCalls` 删除了无效的 `tool_calls`
+- 但没有删除对应的 `tool` 响应消息
+- 导致 `tool` 消息成为"孤儿"
+
+**解决方案**:
+
+**文件**: `packages/core/src/adapters/utils/apiTranslator.ts`
+
+```typescript
+validateAndFixToolCalls(messages: APIMessage[]): APIMessage[] {
+  const result: APIMessage[] = [];
+  const removedToolCallIds = new Set<string>();
+
+  for (const msg of messages) {
+    if (msg.role === 'assistant' && msg.tool_calls) {
+      const validToolCalls = msg.tool_calls.filter(tc => 
+        isValidToolCall(tc)
+      );
+      
+      // 跟踪被删除的 tool_call ID
+      const removed = msg.tool_calls
+        .filter(tc => !validToolCalls.includes(tc))
+        .map(tc => tc.id);
+      removed.forEach(id => removedToolCallIds.add(id));
+
+      if (validToolCalls.length > 0) {
+        result.push({ ...msg, tool_calls: validToolCalls });
+      } else {
+        result.push({ role: 'assistant', content: msg.content || '' });
+      }
+    } 
+    else if (msg.role === 'tool') {
+      // 跳过孤儿 tool 响应
+      if (!removedToolCallIds.has(msg.tool_call_id)) {
+        result.push(msg);
+      }
+    } 
+    else {
+      result.push(msg);
+    }
+  }
+
+  return result;
+}
+```
+
+**效果**: 确保 `tool` 消息始终有对应的 `tool_calls`
+
+---
+
+### Bug 2: 闭包陷阱 - 批量执行停止
+
+**问题描述**:
+- `/todos execute-all` 只执行第一个 todo 就停止
+- Debug 日志显示 `hasExecutionQueue: false`
+- 但 `executionQueue` 状态实际上是 active
+
+**根本原因**:
+- `sendUserMessage` 是一个 `useCallback`
+- 它在创建时捕获了 `executionQueue` 的初始值（null）
+- 当 `executionQueue` 更新时，`sendUserMessage` 仍然使用旧值
+- 这是典型的 React **闭包陷阱**
+
+**解决方案**:
+
+**文件**: `packages/cli/src/ui/hooks/useGeminiStream.ts`
+
+**步骤 1: 创建 refs**
+```typescript
+const executionQueueRef = useRef<ExecutionQueue | null>(null);
+const todosRef = useRef<ExtendedTodo[]>([]);
+const updateTodoRef = useRef(updateTodo);
+const setExecutionQueueRef = useRef(setExecutionQueue);
+const submitQueryRef = useRef<(query: string) => void>();
+```
+
+**步骤 2: 同步 refs 和 props/state**
+```typescript
+useEffect(() => {
+  executionQueueRef.current = executionQueue;
+}, [executionQueue]);
+
+useEffect(() => {
+  todosRef.current = todos;
+}, [todos]);
+
+useEffect(() => {
+  updateTodoRef.current = updateTodo;
+}, [updateTodo]);
+
+useEffect(() => {
+  setExecutionQueueRef.current = setExecutionQueue;
+}, [setExecutionQueue]);
+```
+
+**步骤 3: 在 callback 中使用 refs**
+```typescript
+const handleNextTodo = useCallback(async () => {
+  const currentQueue = executionQueueRef.current; // 使用 ref
+  if (!currentQueue?.active) return null;
+
+  const currentTodos = todosRef.current; // 使用 ref
+  const nextTodo = getNextExecutableTodo(currentTodos);
+
+  if (nextTodo) {
+    setExecutionQueueRef.current({ // 使用 ref
+      ...currentQueue,
+      executingTodoId: nextTodo.id
+    });
+  }
+  
+  // ...
+}, []); // 空依赖数组，因为使用 refs
+```
+
+**步骤 4: sendUserMessage finally 块**
+```typescript
+finally {
+  setIsResponding(false);
+  
+  if (executionQueueRef.current?.active) { // 使用 ref
+    setTimeout(async () => {
+      const nextPrompt = await handleNextTodo();
+      if (nextPrompt) {
+        submitQueryRef.current?.(nextPrompt); // 使用 ref
+      }
+    }, 500);
+  }
+}
+```
+
+**效果**: 
+- `sendUserMessage` 始终访问最新的 `executionQueue` 状态
+- 批量执行正常连续进行
+
+---
+
+### Bug 3: 依赖检查不准确
+
+**问题描述**:
+有依赖的 todo 被错误地允许执行
+
+**解决方案**:
+
+**文件**: `packages/cli/src/utils/todoUtils.ts`
+
+```typescript
+export function checkDependencies(
+  todo: ExtendedTodo,
+  allTodos: ExtendedTodo[]
+): { satisfied: boolean; missing: string[] } {
+  if (!todo.dependencies || todo.dependencies.length === 0) {
+    return { satisfied: true, missing: [] };
+  }
+
+  const missing: string[] = [];
+
+  for (const depId of todo.dependencies) {
+    const depTodo = allTodos.find(t => t.id === depId);
+    
+    if (!depTodo) {
+      missing.push(depId); // 依赖不存在
+    } else if (depTodo.status !== 'completed') {
+      missing.push(depId); // 依赖未完成
+    }
+  }
+
+  return {
+    satisfied: missing.length === 0,
+    missing
+  };
+}
+```
+
+**效果**: 严格验证依赖，确保正确的执行顺序
+
+---
+
+## 技术亮点
+
+### 1. React Hooks 最佳实践
+
+- 使用 `useRef` 避免闭包陷阱
+- `useCallback` 优化性能
+- `useEffect` 同步 props 和 refs
+
+### 2. 类型安全
+
+- 完整的 TypeScript 类型定义
+- 编译时类型检查
+- 运行时参数验证
+
+### 3. 错误处理
+
+- API 错误：自动修复消息格式
+- 执行错误：清理状态，恢复审批模式
+- 中断处理：Ctrl+C 支持
+
+### 4. 用户体验
+
+- 清晰的进度反馈
+- 友好的错误消息
+- 灵活的执行模式
+
+---
+
+## 性能考虑
+
+- **内存管理**: todos 在内存中，轻量高效
+- **UI 响应性**: 使用 setTimeout 延迟确保 UI 更新
+- **批量优化**: 自动续接避免用户手动干预
+
+---
+
+## 未来优化
+
+1. **并行执行**: 对无依赖的 todos 并行执行
+2. **持久化**: 可选的 todos 文件存储
+3. **撤销功能**: 支持回滚已执行的 todo
+4. **执行报告**: 生成详细的执行日志
+
+---
+
+**最后更新**: 2025-10-16  
+**版本**: 1.0.0  
+**状态**: ✅ 已完成
+

--- a/design/plan-todo/README.md
+++ b/design/plan-todo/README.md
@@ -1,0 +1,108 @@
+# Plan+Todo 模式
+
+> **Plan+Todo 模式**让你先规划后执行，通过结构化的计划和任务列表提升开发效率。
+
+---
+
+## 📋 概述
+
+Plan+Todo 模式是一个两阶段的任务执行流程：
+
+1. **Plan 阶段（规划）**：AI 在只读模式下分析需求，创建结构化计划
+2. **Todo 阶段（执行）**：将计划转换为可执行的任务列表，逐步完成
+
+### 核心特性
+
+- 🔒 **安全的 Plan 模式**：只读模式，只分析不修改
+- 📋 **结构化计划**：包含步骤、风险、测试策略
+- ✅ **智能依赖检查**：自动验证任务依赖关系
+- ⚙️ **灵活执行模式**：支持自动和手动审批
+- 🚀 **批量执行**：一键执行所有待办任务
+- 📊 **进度追踪**：清晰的任务状态显示
+
+---
+
+## 📚 文档导航
+
+### 快速开始
+- [USER_GUIDE.md](./USER_GUIDE.md) - 完整用户手册，包含快速开始和最佳实践
+
+### 技术文档
+- [DESIGN_AND_IMPLEMENTATION.md](./DESIGN_AND_IMPLEMENTATION.md) - 架构设计和实现细节
+- [API.md](./API.md) - 命令和工具 API 参考
+
+---
+
+## 🚀 快速示例
+
+### 基本流程
+
+```bash
+# 1. 进入 Plan 模式
+> [Ctrl+P]
+
+# 2. 创建计划
+[PLAN] > 帮我规划实现用户登录功能
+
+# 3. 退出 Plan 模式
+> [Ctrl+P]
+
+# 4. 转换为 todos
+> /plan to-todos
+
+# 5. 执行 todos
+> /todos execute step-1 --mode=auto_edit
+
+# 6. 批量执行所有 todos
+> /todos execute-all --mode=default
+```
+
+---
+
+## 📊 功能状态
+
+| 功能 | 状态 | 说明 |
+|------|------|------|
+| Plan 模式 | ✅ 完成 | Ctrl+P 触发，只读规划 |
+| Todo 管理 | ✅ 完成 | 内存存储，状态管理 |
+| 单个执行 | ✅ 完成 | `/todos execute` |
+| 批量执行 | ✅ 完成 | `/todos execute-all` |
+| 依赖检查 | ✅ 完成 | 自动验证依赖 |
+| 进度追踪 | ✅ 完成 | `/todos list` |
+| JSON 导出 | ✅ 完成 | `/todos export` |
+
+---
+
+## 🎯 典型用例
+
+### 1. 功能开发
+先用 Plan 模式规划架构和步骤，再逐步实现
+
+### 2. 代码重构
+分析风险，制定安全的重构步骤
+
+### 3. 学习代码库
+使用 Plan 模式分析代码结构和依赖关系
+
+### 4. 数据库迁移
+详细规划迁移步骤、回滚方案和风险评估
+
+---
+
+## 🔗 相关资源
+
+### 用户文档
+- [完整用户手册](../../docs/PLAN_TODO_MODE_USER_GUIDE.md)
+
+### 代码实现
+- Core: `packages/core/src/tools/create-plan.ts`
+- Core: `packages/core/src/tools/write-todos.ts`
+- CLI: `packages/cli/src/ui/commands/planCommand.ts`
+- CLI: `packages/cli/src/ui/commands/todosCommand.ts`
+
+---
+
+**实施日期**: 2025-10-16  
+**状态**: ✅ 已完成  
+**版本**: 1.0.0
+

--- a/design/plan-todo/USER_GUIDE.md
+++ b/design/plan-todo/USER_GUIDE.md
@@ -1,0 +1,564 @@
+# Plan+Todo 模式 - 用户指南
+
+> 快速开始、实用场景和最佳实践
+
+---
+
+## 📋 目录
+
+- [快速开始](#快速开始)
+- [核心概念](#核心概念)
+- [实用场景](#实用场景)
+- [最佳实践](#最佳实践)
+- [常见问题](#常见问题)
+
+---
+
+## 快速开始
+
+### 5 分钟上手
+
+#### 第 1 步：进入 Plan 模式
+
+```bash
+> [Ctrl+P]
+
+📋 Plan Mode Activated
+✅ Read-only mode enabled
+💡 Press Ctrl+P again to exit
+```
+
+提示符变为：`[PLAN] >`
+
+#### 第 2 步：创建计划
+
+```bash
+[PLAN] > 帮我规划实现用户登录功能
+```
+
+AI 会分析代码并创建结构化计划：
+
+```
+✅ Plan Created: "Implement User Login"
+
+Steps (5):
+1. step-1: Create User model ⏱️ 30min
+2. step-2: Implement JWT [deps: step-1] ⏱️ 45min
+3. step-3: Create API endpoints [deps: step-2] ⏱️ 30min
+4. step-4: Add frontend login form [deps: step-3] ⏱️ 1h
+5. step-5: Write tests [deps: step-1, step-2, step-3] ⏱️ 1h
+
+Risks: Password hashing, Token security
+```
+
+#### 第 3 步：退出 Plan 模式
+
+```bash
+[PLAN] > [Ctrl+P]
+
+📋 Exited Plan Mode
+💡 Use /plan to-todos to convert to executable todos
+```
+
+#### 第 4 步：转换并执行
+
+```bash
+# 转换为 todos
+> /plan to-todos
+✅ Created 5 todos
+
+# 查看列表
+> /todos list
+
+# 执行第一个（自动模式）
+> /todos execute step-1 --mode=auto_edit
+✓ write_file models/User.ts
+✅ Task completed
+
+# 标记完成
+> /todos update step-1 completed
+
+# 或一键批量执行
+> /todos execute-all --mode=auto_edit
+```
+
+---
+
+## 核心概念
+
+### Plan 模式
+
+**什么是 Plan 模式？**
+- 只读模式，AI 只分析不修改代码
+- 创建结构化计划（步骤、风险、测试）
+- 通过 `Ctrl+P` 切换
+
+**Plan 模式下 AI 可以做什么？**
+- ✅ 读取文件
+- ✅ 搜索代码
+- ✅ 创建计划
+- ❌ 不能修改文件
+- ❌ 不能执行命令
+
+**为什么需要 Plan 模式？**
+- 先规划后执行，避免盲目修改
+- 识别风险，制定测试策略
+- 让 AI 专注于思考和分析
+
+---
+
+### Todo 管理
+
+**Todo 生命周期**:
+```
+Plan 创建 → /plan to-todos → pending → execute → in_progress → update → completed
+```
+
+**Todo 状态**:
+- `pending` ⬜: 待执行
+- `in_progress` 🔄: 执行中
+- `completed` ✅: 已完成
+- `cancelled` ❌: 已取消
+
+**优先级**（自动分配）:
+- `HIGH`: 前 3 个步骤
+- `MEDIUM`: 4-6 个步骤
+- `LOW`: 7 个及之后
+
+---
+
+### 执行模式
+
+**Default 模式**（默认）:
+- 需要手动确认每个操作
+- 安全性高，适合重要代码
+
+**Auto-edit 模式**:
+- 自动批准所有操作
+- 速度快，适合信任的任务
+
+**如何选择？**
+- 核心业务逻辑 → `default`
+- 数据库操作 → `default`
+- UI 组件 → `auto_edit`
+- 测试代码 → `auto_edit`
+- 文档 → `auto_edit`
+
+---
+
+### 依赖管理
+
+**什么是依赖？**
+- 某个 todo 必须等其他 todo 完成后才能执行
+
+**示例**:
+```bash
+⬜ step-2 - Implement JWT
+   🔗 Dependencies: step-1
+```
+
+**自动检查**:
+```bash
+> /todos execute step-2
+
+❌ Cannot execute step-2. Dependencies not completed:
+- step-1
+```
+
+---
+
+## 实用场景
+
+### 场景 1：添加新功能
+
+**需求**: 为博客添加评论功能
+
+```bash
+# 1. 规划
+> [Ctrl+P]
+[PLAN] > 帮我规划如何添加评论功能，包括评论、回复、点赞
+
+# 2. 转换
+> [Ctrl+P]
+> /plan to-todos
+
+# 3. 批量执行
+> /todos execute-all --mode=auto_edit
+```
+
+---
+
+### 场景 2：代码重构
+
+**需求**: 重构混乱的工具函数
+
+```bash
+# 1. 分析和规划
+> [Ctrl+P]
+[PLAN] > 分析 utils.js，规划如何重构为多个模块
+
+# 2. 查看计划
+> /plan show
+
+# 3. 谨慎执行（default 模式）
+> [Ctrl+P]
+> /plan to-todos
+> /todos execute step-1 --mode=default
+[仔细确认每个修改...]
+```
+
+---
+
+### 场景 3：学习代码库
+
+**需求**: 理解新项目
+
+```bash
+# 只用 Plan 模式分析
+> [Ctrl+P]
+[PLAN] > 分析这个项目的架构，包括模块、数据流、依赖关系
+
+# 查看完整分析
+> /plan show
+
+# 不需要执行，只用于学习
+```
+
+---
+
+### 场景 4：数据库迁移
+
+**需求**: 升级数据库 schema
+
+```bash
+# 1. 详细规划
+> [Ctrl+P]
+[PLAN] > 规划数据库迁移，包括备份、迁移脚本、回滚方案、风险评估
+
+# 2. 查看风险
+> /plan show
+
+# 3. 仔细执行
+> [Ctrl+P]
+> /plan to-todos
+> /todos execute step-1 --mode=default
+[每步都仔细确认]
+```
+
+---
+
+### 场景 5：批量任务
+
+**需求**: 一次性执行多个相关任务
+
+```bash
+# 1. 创建计划
+> [Ctrl+P]
+[PLAN] > 规划实现完整的购物车功能
+
+# 2. 转换为 todos
+> [Ctrl+P]
+> /plan to-todos
+
+# 3. 批量执行
+> /todos execute-all --mode=auto_edit
+
+# 输出：
+🚀 Starting Batch Execution
+📊 Total todos: 8
+
+▶️  [1/8] Create Cart model...
+✓ write_file models/Cart.ts
+
+▶️  [2/8] Add Cart API...
+✓ write_file api/cart.ts
+
+[...]
+
+✅ Batch Execution Complete!
+📊 Executed 8/8 todos in 5 minutes
+```
+
+**中断和恢复**:
+```bash
+# 执行到一半按 Ctrl+C
+^C
+⏸️  Batch Execution Interrupted
+Completed: 3/8 todos
+
+# 查看进度
+> /todos list
+
+# 继续执行剩余
+> /todos execute-all --mode=auto_edit
+```
+
+---
+
+## 最佳实践
+
+### 1. 何时使用 Plan 模式
+
+**✅ 推荐使用**:
+- 复杂的多步骤任务（3+ 步骤）
+- 跨多个文件/模块的功能
+- 需要风险评估的操作
+- 不熟悉的代码库
+- 重要的业务逻辑
+
+**❌ 不推荐使用**:
+- 简单的单文件修改
+- 明确的小任务
+- 紧急 Bug 修复
+- 文档/注释更新
+
+---
+
+### 2. 规划阶段技巧
+
+**提供充分的上下文**:
+
+✅ 好的示例:
+```bash
+[PLAN] > 这是一个 React + TypeScript + Express 项目。
+当前使用 JWT 认证。
+我想添加 OAuth 2.0 支持（Google 和 GitHub 登录）。
+请规划实现步骤，考虑向后兼容性。
+```
+
+❌ 不好的示例:
+```bash
+[PLAN] > 添加 OAuth
+```
+
+**明确要求**:
+```bash
+[PLAN] > 规划实现用户权限系统，需要包括：
+1. 角色定义（管理员、编辑、读者）
+2. 权限检查中间件
+3. 前端权限控制
+4. 测试用例
+请给出详细的实现步骤和风险分析。
+```
+
+**审查计划**:
+```bash
+> /plan show
+
+检查：
+- ✅ 步骤顺序是否合理？
+- ✅ 依赖关系是否正确？
+- ✅ 是否遗漏重要步骤？
+- ✅ 风险评估是否全面？
+```
+
+---
+
+### 3. 执行阶段技巧
+
+**逐步执行，及时验证**:
+
+✅ 推荐:
+```bash
+> /todos execute step-1 --mode=auto_edit
+[验证结果...]
+> /todos update step-1 completed
+> /todos list
+> /todos execute step-2
+```
+
+❌ 不推荐:
+```bash
+# 连续执行多个，不验证
+> /todos execute step-1 --mode=auto_edit
+> /todos execute step-2 --mode=auto_edit
+> /todos execute step-3 --mode=auto_edit
+```
+
+**处理依赖关系**:
+```bash
+# 检查依赖
+> /todos list
+
+# 先完成依赖
+> /todos execute step-1
+> /todos update step-1 completed
+
+# 再执行当前
+> /todos execute step-2
+```
+
+---
+
+### 4. 批量执行技巧
+
+**适合批量执行的场景**:
+- 信任的任务列表
+- 简单的批量操作
+- 测试或文档任务
+
+**批量执行流程**:
+```bash
+# 1. 查看待执行 todos
+> /todos list
+
+# 2. 选择合适的模式
+> /todos execute-all --mode=auto_edit  # 快速
+> /todos execute-all --mode=default    # 安全
+
+# 3. 监控进度
+[观察执行过程]
+
+# 4. 需要时中断
+[Ctrl+C]
+
+# 5. 查看结果
+> /todos list
+```
+
+---
+
+### 5. 进度管理技巧
+
+**定期查看进度**:
+```bash
+> /todos list
+
+📋 Progress:
+✅ 3 completed | 🔄 0 in progress | ⬜ 2 pending
+```
+
+**导出进度报告**:
+```bash
+> /todos export > progress-2025-10-16.json
+```
+
+**处理问题任务**:
+```bash
+# 取消不需要的任务
+> /todos update step-4 cancelled
+
+# 重新执行失败的任务
+> /todos update step-2 pending
+> /todos execute step-2 --mode=default
+```
+
+---
+
+### 6. 团队协作技巧
+
+**分享计划**:
+```bash
+> /plan show > docs/implementation-plan.md
+# git add docs/implementation-plan.md
+# git commit -m "Add implementation plan"
+```
+
+**分享进度**:
+```bash
+> /todos export > progress/week-42.json
+```
+
+---
+
+## 常见问题
+
+### Q1: Plan 模式和普通模式有什么区别？
+
+**A**: 
+- Plan 模式：只读，只分析不修改，创建计划
+- 普通模式：可以执行所有操作
+
+### Q2: Todos 保存在哪里？
+
+**A**: 内存中，关闭 CLI 后清空。
+- 备份：`/todos export > backup.json`
+
+### Q3: 为什么我的 todo 无法执行？
+
+**A**: 最常见原因是依赖未完成。
+```bash
+> /todos list  # 查看依赖
+> /todos execute <依赖的 todo>
+```
+
+### Q4: Default 和 Auto-edit 有什么区别？
+
+**A**:
+- Default: 每次操作需确认，安全
+- Auto-edit: 自动批准，快速
+
+### Q5: 批量执行可以中断吗？
+
+**A**: 可以。按 `Ctrl+C` 中断，然后：
+```bash
+> /todos list  # 查看进度
+> /todos execute-all  # 继续执行剩余
+```
+
+### Q6: 如何修改计划？
+
+**A**: 
+```bash
+> /plan clear
+> [Ctrl+P]
+[PLAN] > 重新描述需求...
+```
+
+### Q7: 可以跳过某个步骤吗？
+
+**A**:
+```bash
+> /todos update step-3 cancelled
+```
+
+### Q8: 如何查看执行历史？
+
+**A**:
+```bash
+> /todos export  # 包含执行时间等信息
+```
+
+---
+
+## 命令速查表
+
+### 快捷键
+
+| 快捷键 | 功能 |
+|--------|------|
+| `Ctrl+P` | 切换 Plan 模式 |
+| `Ctrl+C` | 中断执行 |
+
+### Plan 命令
+
+| 命令 | 说明 |
+|------|------|
+| `/plan show` | 显示计划 |
+| `/plan to-todos` | 转换为 todos |
+| `/plan clear` | 清除计划 |
+
+### Todo 命令
+
+| 命令 | 说明 |
+|------|------|
+| `/todos list` | 列出 todos |
+| `/todos execute <id> [--mode]` | 执行单个 |
+| `/todos execute-all [--mode]` | 批量执行 |
+| `/todos update <id> <status>` | 更新状态 |
+| `/todos export` | 导出 JSON |
+| `/todos clear` | 清除所有 |
+
+---
+
+## 下一步
+
+- 📖 查看 [API 参考](./API.md) 了解详细命令语法
+- 🏗️ 查看 [设计与实现](./DESIGN_AND_IMPLEMENTATION.md) 了解技术细节
+- 💡 开始使用：按 `Ctrl+P` 进入 Plan 模式！
+
+---
+
+**最后更新**: 2025-10-16  
+**版本**: 1.0.0
+

--- a/docs/PLAN_TODO_MODE_USER_GUIDE.md
+++ b/docs/PLAN_TODO_MODE_USER_GUIDE.md
@@ -1,0 +1,2374 @@
+# TianGong CLI - Plan+Todo 模式使用手册
+
+## 📖 目录
+
+- [功能概述](#功能概述)
+- [快速开始](#快速开始)
+- [Plan 模式详解](#plan-模式详解)
+- [Todo 管理详解](#todo-管理详解)
+- [命令参考](#命令参考)
+- [使用场景](#使用场景)
+- [最佳实践](#最佳实践)
+- [常见问题](#常见问题)
+- [故障排除](#故障排除)
+
+---
+
+## 功能概述
+
+### 什么是 Plan+Todo 模式？
+
+Plan+Todo 模式是 TianGong CLI 的一项强大功能，它将复杂任务分解为两个阶段：
+
+1. **Plan 阶段（规划）**：AI 分析需求，创建详细的执行计划
+2. **Todo 阶段（执行）**：将计划转换为可执行的任务列表，逐步完成
+
+### 为什么需要 Plan+Todo 模式？
+
+**传统方式的问题**：
+- ❌ 直接执行复杂任务容易出错
+- ❌ 缺少整体规划，步骤混乱
+- ❌ 难以追踪进度
+- ❌ 依赖关系不清晰
+
+**Plan+Todo 模式的优势**：
+- ✅ 先规划后执行，思路清晰
+- ✅ 结构化的任务分解
+- ✅ 清晰的进度追踪
+- ✅ 自动的依赖管理
+- ✅ 灵活的执行控制
+
+### 核心特性
+
+| 特性 | 说明 |
+|------|------|
+| 🔒 **安全的 Plan 模式** | 只读模式，只分析不修改 |
+| 📋 **结构化计划** | 包含步骤、风险、测试策略 |
+| ✅ **智能依赖检查** | 自动验证任务依赖关系 |
+| ⚙️ **灵活执行模式** | 支持自动和手动审批 |
+| 📊 **进度追踪** | 清晰的任务状态显示 |
+| 💾 **轻量设计** | 内存存储，支持 JSON 导出 |
+
+---
+
+## 快速开始
+
+### 第一次使用（5 分钟教程）
+
+#### 步骤 1：进入 Plan 模式
+
+按下 `Ctrl+P` 快捷键：
+
+```bash
+> [Ctrl+P]
+
+📋 Plan Mode Activated
+
+✅ Read-only mode enabled
+✅ Only analysis and planning tools available
+✅ AI will use create_plan tool for structured output
+
+💡 Press Ctrl+P again to exit Plan mode
+```
+
+此时提示符会变为：`[PLAN] >`
+
+#### 步骤 2：让 AI 创建计划
+
+输入您想要实现的功能：
+
+```bash
+[PLAN] > 帮我添加用户登录功能
+```
+
+AI 会：
+1. 📖 读取项目相关代码
+2. 🔍 分析技术栈和架构
+3. 📋 创建详细的执行计划
+
+输出示例：
+```
+✅ Plan Created: "Implement User Login"
+
+**Overview**: Add JWT-based authentication with login/logout endpoints
+
+## Steps (5):
+
+1. step-1: Create User model with email and password fields
+   - Module: backend/models
+   - Estimated: 30min
+
+2. step-2: Implement JWT token generation and validation
+   - Module: backend/auth
+   - Dependencies: step-1
+   - Risks: Token security vulnerabilities
+   - Estimated: 45min
+
+3. step-3: Create login and logout API endpoints
+   - Module: backend/api
+   - Dependencies: step-2
+   - Estimated: 30min
+
+4. step-4: Add frontend login form
+   - Module: frontend/components
+   - Dependencies: step-3
+   - Estimated: 1h
+
+5. step-5: Write unit and integration tests
+   - Module: tests
+   - Dependencies: step-1, step-2, step-3
+   - Estimated: 1h
+
+## Overall Risks:
+- Password hashing performance issues
+- Session management complexity
+- Token refresh mechanism
+
+## Testing Strategy:
+Unit tests for User model and JWT utils
+Integration tests for login/logout flow
+E2E tests for frontend form
+```
+
+#### 步骤 3：退出 Plan 模式
+
+再次按 `Ctrl+P`：
+
+```bash
+[PLAN] > [Ctrl+P]
+
+📋 Exited Plan Mode
+
+📝 Plan "Implement User Login" created
+💡 Use /plan to-todos to convert to executable todos
+```
+
+#### 步骤 4：查看和转换计划
+
+```bash
+# 查看完整计划
+> /plan show
+
+# 将计划转换为可执行的 todos
+> /plan to-todos
+
+✅ Created 5 todos from plan "Implement User Login"
+
+💡 Next steps:
+- /todos list - View all todos
+- /todos execute <id> - Execute a todo
+- /todos export - Export to JSON
+```
+
+#### 步骤 5：查看 Todo 列表
+
+```bash
+> /todos list
+
+📋 Todo List (5 total)
+
+✅ 0 completed | 🔄 0 in progress | ⬜ 5 pending | ❌ 0 cancelled
+
+### HIGH Priority
+
+⬜ step-1 - Create User model with email and password fields ⏱️ 30min
+   📦 Module: backend/models
+
+⬜ step-2 - Implement JWT token generation and validation ⏱️ 45min
+   📦 Module: backend/auth
+   🔗 Dependencies: step-1
+   ⚠️  Token security vulnerabilities
+
+### MEDIUM Priority
+
+⬜ step-3 - Create login and logout API endpoints ⏱️ 30min
+   📦 Module: backend/api
+   🔗 Dependencies: step-2
+
+⬜ step-4 - Add frontend login form ⏱️ 1h
+   📦 Module: frontend/components
+   🔗 Dependencies: step-3
+
+### LOW Priority
+
+⬜ step-5 - Write unit and integration tests ⏱️ 1h
+   📦 Module: tests
+   🔗 Dependencies: step-1, step-2, step-3
+```
+
+#### 步骤 6：执行第一个 Todo
+
+```bash
+# 使用自动模式执行（快速，适合信任的任务）
+> /todos execute step-1 --mode=auto_edit
+
+🔄 Executing: Create User model with email and password fields
+
+📌 ID: step-1
+⚙️ Approval mode: auto_edit
+📦 Module: backend/models
+⏱️  Estimated: 30min
+
+[AI 开始执行...]
+
+✓ write_file backend/models/User.ts
+✓ edit backend/config/database.ts
+✓ edit backend/index.ts
+
+✅ Task completed successfully!
+```
+
+#### 步骤 7：更新任务状态
+
+```bash
+> /todos update step-1 completed
+
+✅ Updated step-1 → completed
+
+📋 Current progress:
+✅ 1 completed | 🔄 0 in progress | ⬜ 4 pending
+```
+
+#### 步骤 8：继续执行下一个任务
+
+```bash
+# 使用默认模式（需要确认，更安全）
+> /todos execute step-2 --mode=default
+
+🔄 Executing: Implement JWT token generation and validation
+
+⚠️ edit backend/auth/jwt.ts
+This will modify authentication logic.
+Confirm? (y/n): y
+
+✓ edit backend/auth/jwt.ts
+
+⚠️ write_file backend/auth/middleware.ts
+Confirm? (y/n): y
+
+✓ write_file backend/auth/middleware.ts
+
+✅ Task completed successfully!
+```
+
+#### 步骤 9：导出进度（可选）
+
+```bash
+> /todos export
+
+📄 Todos JSON Export
+
+{
+  "version": "1.0",
+  "generatedAt": "2025-10-16T12:30:00.000Z",
+  "sourcePlan": "Implement User Login",
+  "todos": [
+    {
+      "id": "step-1",
+      "description": "Create User model with email and password fields",
+      "status": "completed",
+      "priority": "high",
+      "module": "backend/models",
+      "completedAt": "2025-10-16T12:25:00.000Z"
+    },
+    {
+      "id": "step-2",
+      "description": "Implement JWT token generation and validation",
+      "status": "completed",
+      "priority": "high",
+      "dependencies": ["step-1"]
+    },
+    ...
+  ],
+  "statistics": {
+    "total": 5,
+    "pending": 3,
+    "in_progress": 0,
+    "completed": 2,
+    "cancelled": 0
+  }
+}
+
+💡 Copy this JSON for:
+- External automation tools
+- Project management systems
+- Progress tracking
+```
+
+---
+
+## Plan 模式详解
+
+### 什么是 Plan 模式？
+
+Plan 模式是一个**只读的规划模式**，在这个模式下：
+- ✅ AI 可以读取代码、搜索文件、分析架构
+- ✅ AI 会创建结构化的执行计划
+- ❌ AI 不能修改代码、执行命令、写文件
+
+### 为什么需要只读模式？
+
+**安全性**：
+- 避免在规划阶段误操作
+- 让 AI 专注于分析和思考
+- 给用户审查计划的机会
+
+**质量保证**：
+- 先想清楚再动手
+- 完整的风险分析
+- 明确的测试策略
+
+### 如何使用 Plan 模式
+
+#### 1. 进入 Plan 模式
+
+**快捷键**：`Ctrl+P`
+
+**提示符变化**：
+```bash
+> [Ctrl+P]
+[PLAN] >  # 注意提示符前缀
+```
+
+#### 2. 提出规划需求
+
+**好的示例**：
+```bash
+[PLAN] > 帮我规划如何实现用户评论功能，包括评论、回复、点赞
+
+[PLAN] > 分析现有代码，规划如何重构用户认证模块以支持 OAuth
+
+[PLAN] > 我想添加数据导出功能，规划需要修改哪些模块
+```
+
+**不太好的示例**：
+```bash
+[PLAN] > 改代码  # 太模糊
+
+[PLAN] > 添加功能  # 没有说明什么功能
+
+[PLAN] > 帮我写个函数  # Plan 模式用于规划，不是简单任务
+```
+
+#### 3. AI 创建计划
+
+AI 会自动调用 `create_plan` 工具，生成包含以下内容的计划：
+
+**计划结构**：
+```
+✅ Plan Created: "计划标题"
+
+Overview: 计划概述
+
+Steps: 执行步骤（包含 ID、描述、模块、依赖、风险、时间估计）
+
+Overall Risks: 整体风险
+
+Testing Strategy: 测试策略
+
+Estimated Duration: 总体时间估计
+```
+
+#### 4. 审查计划
+
+```bash
+> /plan show  # 查看完整计划内容
+```
+
+仔细检查：
+- ✅ 步骤是否完整？
+- ✅ 依赖关系是否正确？
+- ✅ 风险是否被识别？
+- ✅ 测试策略是否充分？
+
+#### 5. 退出 Plan 模式
+
+**快捷键**：再次按 `Ctrl+P`
+
+```bash
+[PLAN] > [Ctrl+P]
+
+📋 Exited Plan Mode
+📝 Plan "..." created
+```
+
+### Plan 模式下 AI 可以使用的工具
+
+| 工具类型 | 工具名称 | 说明 |
+|---------|---------|------|
+| 📖 读取文件 | `read_file` | 读取单个文件 |
+| 📚 批量读取 | `read_many_files` | 一次读取多个文件 |
+| 📁 列出文件 | `ls` | 列出目录内容 |
+| 🔍 搜索代码 | `grep`, `rg` | 搜索代码内容 |
+| 🌐 查找文件 | `glob` | 按模式查找文件 |
+| 🌍 网络查询 | `web_fetch`, `web_search` | 查询技术文档 |
+| 📋 创建计划 | `create_plan` | **生成结构化计划** |
+
+### Plan 模式下 AI 不能使用的工具
+
+| 工具类型 | 说明 | 原因 |
+|---------|------|------|
+| ✏️ 编辑文件 | `edit`, `smart_edit` | 只读模式 |
+| 📝 写文件 | `write_file` | 只读模式 |
+| 🔧 执行命令 | `run_shell_command`, `bash` | 安全考虑 |
+| 📝 其他写操作 | 任何修改文件系统的操作 | 只读模式 |
+
+### Plan 模式最佳实践
+
+#### ✅ 适合使用 Plan 模式的场景
+
+1. **复杂的多步骤任务**
+   ```bash
+   [PLAN] > 规划实现完整的购物车功能
+   ```
+
+2. **跨模块的大型重构**
+   ```bash
+   [PLAN] > 分析并规划如何将单体应用拆分为微服务
+   ```
+
+3. **不熟悉的代码库**
+   ```bash
+   [PLAN] > 分析这个项目的架构，规划如何添加新功能
+   ```
+
+4. **需要风险评估的任务**
+   ```bash
+   [PLAN] > 规划数据库迁移方案，包括风险分析
+   ```
+
+#### ❌ 不需要 Plan 模式的场景
+
+1. **简单的单文件修改**
+   ```bash
+   # 直接执行即可
+   > 修改 utils.ts 中的 formatDate 函数
+   ```
+
+2. **明确知道怎么做的小任务**
+   ```bash
+   # 直接执行
+   > 给这个函数添加注释
+   ```
+
+3. **紧急 Bug 修复**
+   ```bash
+   # 直接修复
+   > 修复登录页面的空指针错误
+   ```
+
+---
+
+## Todo 管理详解
+
+### Todo 生命周期
+
+```
+Plan 创建
+  ↓
+/plan to-todos  ← 转换为 todos（内存存储）
+  ↓
+Todo: pending（待执行）
+  ↓
+/todos execute  ← 开始执行
+  ↓
+Todo: in_progress（执行中）
+  ↓
+执行完成
+  ↓
+/todos update → completed  ← 标记完成
+```
+
+### Todo 状态说明
+
+| 状态 | 图标 | 说明 | 何时使用 |
+|------|------|------|----------|
+| `pending` | ⬜ | 待执行 | 默认状态 |
+| `in_progress` | 🔄 | 执行中 | 自动设置（执行时） |
+| `completed` | ✅ | 已完成 | 任务成功完成 |
+| `cancelled` | ❌ | 已取消 | 任务不再需要 |
+
+### Todo 优先级
+
+系统自动根据步骤顺序分配优先级：
+
+| 优先级 | 范围 | 说明 |
+|--------|------|------|
+| **HIGH** | 前 3 个步骤 | 优先执行 |
+| **MEDIUM** | 4-6 个步骤 | 中等优先级 |
+| **LOW** | 第 7 个及之后 | 后续执行 |
+
+### 依赖管理
+
+#### 什么是依赖？
+
+某个 todo 必须等待其他 todo 完成后才能执行。
+
+**示例**：
+```bash
+⬜ step-2 - Implement JWT token generation
+   🔗 Dependencies: step-1
+```
+
+这表示：必须先完成 `step-1` 才能执行 `step-2`
+
+#### 依赖检查
+
+系统会自动检查依赖：
+
+```bash
+> /todos execute step-3
+
+❌ Cannot execute step-3. Dependencies not completed:
+- step-1
+- step-2
+
+Complete dependencies first.
+```
+
+**解决方法**：
+1. 先执行依赖的 todos
+2. 标记它们为 completed
+3. 然后再执行当前 todo
+
+### 执行模式
+
+#### Default 模式（默认模式）
+
+**特点**：
+- ⚠️ 需要手动确认每个操作
+- ✅ 安全性高
+- ⏱️ 速度较慢
+
+**适用场景**：
+- 核心业务逻辑
+- 数据库操作
+- 配置文件修改
+- 不熟悉的代码
+
+**示例**：
+```bash
+> /todos execute step-1 --mode=default
+
+⚠️ write_file models/User.ts
+This will create a new file.
+Confirm? (y/n): y  ← 需要确认
+
+✓ write_file models/User.ts
+
+⚠️ edit config/database.ts
+This will modify database configuration.
+Confirm? (y/n): y  ← 需要确认
+
+✓ edit config/database.ts
+```
+
+#### Auto-edit 模式（自动模式）
+
+**特点**：
+- ✅ 自动批准所有编辑操作
+- ⚡ 速度快
+- ⚠️ 风险较高
+
+**适用场景**：
+- UI 组件开发
+- 样式调整
+- 测试代码
+- 文档编写
+- 信任 AI 的场景
+
+**示例**：
+```bash
+> /todos execute step-1 --mode=auto_edit
+
+🟢 Auto-edit mode enabled for this task
+
+✓ write_file models/User.ts (auto-approved)
+✓ edit config/database.ts (auto-approved)
+✓ edit index.ts (auto-approved)
+
+✅ Task completed
+```
+
+#### 如何选择执行模式？
+
+**决策树**：
+```
+这个任务会影响核心功能吗？
+├─ 是 → 使用 default 模式 ✅
+└─ 否
+    └─ 这个任务容易回滚吗？
+        ├─ 是 → 可以使用 auto_edit 模式 ⚡
+        └─ 否 → 使用 default 模式 ✅
+```
+
+**推荐配置**：
+
+| 任务类型 | 推荐模式 | 原因 |
+|----------|----------|------|
+| 数据库迁移 | `default` | 不可逆操作 |
+| 认证授权 | `default` | 安全关键 |
+| 支付逻辑 | `default` | 业务关键 |
+| API 端点 | `default` | 影响接口 |
+| UI 组件 | `auto_edit` | 容易回滚 |
+| 样式文件 | `auto_edit` | 低风险 |
+| 测试代码 | `auto_edit` | 独立模块 |
+| 文档 | `auto_edit` | 无风险 |
+
+### Todo 列表显示
+
+#### 基本显示
+
+```bash
+> /todos list
+
+📋 Todo List (5 total)
+
+✅ 2 completed | 🔄 1 in progress | ⬜ 2 pending | ❌ 0 cancelled
+```
+
+#### 按优先级分组
+
+```bash
+### HIGH Priority
+
+⬜ step-1 - Task description ⏱️ 30min
+   📦 Module: backend/models
+
+### MEDIUM Priority
+
+🔄 step-3 - Task description [deps: step-1, step-2]
+   ⚠️  Some risk warning
+```
+
+#### 已完成的任务
+
+```bash
+### ✅ Completed (2)
+
+✅ step-1 - Task description
+✅ step-2 - Task description
+```
+
+---
+
+## 命令参考
+
+### Plan 相关命令
+
+#### `/plan show`
+
+**功能**：显示当前计划的详细内容
+
+**语法**：
+```bash
+/plan show
+```
+
+**输出示例**：
+```
+# 📋 Implement User Login
+
+**Overview**: Add JWT-based authentication...
+
+## 🔢 Steps (5)
+
+1. **step-1**: Create User model
+   - 📦 Module: backend/models
+   - ⏱️  Estimated: 30min
+
+...
+```
+
+**使用场景**：
+- 查看完整计划
+- 审查步骤和风险
+- 分享给团队
+
+---
+
+#### `/plan to-todos`
+
+**功能**：将当前计划转换为可执行的 todo 列表
+
+**语法**：
+```bash
+/plan to-todos
+```
+
+**效果**：
+- 创建 todos（存储在内存）
+- 自动分配优先级
+- 保留依赖关系
+
+**输出示例**：
+```
+✅ Created 5 todos from plan "Implement User Login"
+
+💡 Next steps:
+- /todos list - View all todos
+- /todos execute <id> - Execute a todo
+```
+
+**注意事项**：
+- ⚠️ 会覆盖已存在的 todos
+- ⚠️ 内存存储，会话结束后清空
+
+---
+
+#### `/plan clear`
+
+**功能**：清除当前计划
+
+**语法**：
+```bash
+/plan clear
+```
+
+**效果**：
+- 删除当前 plan 数据
+- 不影响已创建的 todos
+
+**使用场景**：
+- 重新规划
+- 切换到其他任务
+
+---
+
+### Todo 相关命令
+
+#### `/todos list`
+
+**功能**：显示所有 todo 列表
+
+**语法**：
+```bash
+/todos list
+```
+
+**显示内容**：
+- 统计信息（总数、各状态数量）
+- 按优先级分组的活跃任务
+- 已完成和已取消的任务
+
+**输出示例**：
+```
+📋 Todo List (5 total)
+
+✅ 2 | 🔄 1 | ⬜ 2 | ❌ 0
+
+### HIGH Priority
+⬜ step-1 - Description...
+```
+
+---
+
+#### `/todos execute`
+
+**功能**：执行指定的 todo
+
+**语法**：
+```bash
+/todos execute <id> [--mode=auto_edit|default]
+```
+
+**参数**：
+- `<id>`：必需，todo 的 ID（如 `step-1`）
+- `--mode`：可选，执行模式
+  - `default`：默认模式，需要确认（默认值）
+  - `auto_edit`：自动模式，自动批准
+
+**示例**：
+```bash
+# 使用默认模式
+/todos execute step-1
+
+# 使用自动模式
+/todos execute step-1 --mode=auto_edit
+
+# 明确指定默认模式
+/todos execute step-1 --mode=default
+```
+
+**执行流程**：
+1. 检查依赖是否完成
+2. 设置执行模式
+3. 显示任务信息
+4. 开始执行
+5. 提示更新状态
+
+**依赖检查**：
+```bash
+> /todos execute step-3
+
+❌ Cannot execute step-3. Dependencies not completed:
+- step-1
+- step-2
+```
+
+---
+
+#### `/todos execute-all`
+
+**功能**：批量执行所有待执行的 todos，按顺序自动执行
+
+**语法**：
+```bash
+/todos execute-all [--mode=auto_edit|default]
+```
+
+**参数**：
+- `--mode`：可选，执行模式
+  - `default`：默认模式，需要确认（默认值）
+  - `auto_edit`：自动模式，自动批准所有操作
+
+**特性**：
+- 🔄 自动按顺序执行所有待执行 todos
+- 🔗 自动检查依赖关系，确保正确顺序
+- 📊 实时显示进度 (X/Y completed)
+- ⏸️ Ctrl+C 随时中断
+- 🛡️ 错误自动恢复
+
+**示例**：
+```bash
+# 使用默认模式（安全，每个操作需要确认）
+> /todos execute-all --mode=default
+
+🚀 Starting Batch Execution
+
+📊 Total todos: 5
+⚙️ Approval mode: default
+🎯 First todo: Create User model with email and password fields
+
+💡 Press Ctrl+C to stop at any time
+
+---
+
+▶️  [1/5] Create User model with email and password fields
+📦 Module: backend/models
+⏱️  Estimated: 30min
+
+⚠️ write_file backend/models/User.ts
+Confirm? (y/n): y
+✓ write_file backend/models/User.ts
+
+✅ Task 1 completed
+
+---
+
+▶️  [2/5] Implement JWT token generation and validation
+📦 Module: backend/auth
+⏱️  Estimated: 45min
+
+[继续执行...]
+
+---
+
+✅ Batch Execution Complete!
+
+📊 Executed 5/5 todos
+
+Use /todos list to see final status
+```
+
+```bash
+# 使用自动模式（快速，全自动执行）
+> /todos execute-all --mode=auto_edit
+
+🚀 Starting Batch Execution
+
+📊 Total todos: 5
+⚙️ Approval mode: auto_edit
+🎯 First todo: Create User model
+
+---
+
+▶️  [1/5] Create User model ⏱️ 30min
+✓ write_file backend/models/User.ts (auto-approved)
+✓ edit backend/config/database.ts (auto-approved)
+
+▶️  [2/5] Implement JWT authentication ⏱️ 45min
+✓ write_file backend/auth/jwt.ts (auto-approved)
+✓ write_file backend/auth/middleware.ts (auto-approved)
+
+▶️  [3/5] Create API endpoints ⏱️ 30min
+[...]
+
+✅ Batch Execution Complete!
+📊 Executed 5/5 todos in 2.5 minutes
+```
+
+**中断执行**：
+```bash
+> /todos execute-all --mode=auto_edit
+
+▶️  [2/5] Implement JWT authentication...
+
+^C  ← 按 Ctrl+C 中断
+
+⏸️  Batch Execution Interrupted
+
+Completed: 1/5 todos
+
+Use /todos list to see current progress
+Use /todos execute-all to resume remaining todos
+```
+
+**错误处理**：
+```bash
+> /todos execute-all --mode=default
+
+▶️  [3/5] Create API endpoints...
+
+❌ Error: File already exists
+
+❌ Batch Execution Failed
+
+Todo 3/5 encountered an error.
+
+Progress: 2 completed, 1 failed
+
+💡 Fix the issue and run /todos execute-all to continue with remaining todos
+```
+
+**适用场景**：
+- ✅ 信任的任务列表（使用 auto_edit 模式）
+- ✅ 简单的批量操作
+- ✅ 测试或文档相关任务
+- ⚠️ 不适合核心业务逻辑（建议逐个执行）
+
+**注意事项**：
+- 批量执行会按顺序执行所有 `pending` 状态的 todos
+- 已完成（`completed`）或已取消（`cancelled`）的 todos 会被跳过
+- 自动检查依赖关系，确保依赖任务先完成
+- 中断后可以随时恢复执行剩余 todos
+
+---
+
+#### `/todos update`
+
+**功能**：更新 todo 的状态
+
+**语法**：
+```bash
+/todos update <id> <status>
+```
+
+**参数**：
+- `<id>`：todo 的 ID
+- `<status>`：新状态
+  - `pending`：待执行
+  - `in_progress`：执行中
+  - `completed`：已完成
+  - `cancelled`：已取消
+
+**示例**：
+```bash
+# 标记为已完成
+/todos update step-1 completed
+
+# 标记为取消
+/todos update step-5 cancelled
+
+# 重置为待执行
+/todos update step-2 pending
+```
+
+**输出示例**：
+```
+✅ Updated step-1 → completed
+
+Current todo list:
+[显示更新后的列表]
+```
+
+---
+
+#### `/todos export`
+
+**功能**：导出 todos 为 JSON 格式
+
+**语法**：
+```bash
+/todos export
+```
+
+**输出格式**：
+```json
+{
+  "version": "1.0",
+  "generatedAt": "2025-10-16T12:00:00.000Z",
+  "sourcePlan": "Plan title",
+  "todos": [
+    {
+      "id": "step-1",
+      "description": "...",
+      "status": "completed",
+      "priority": "high",
+      "module": "...",
+      "dependencies": [],
+      "risks": [],
+      "estimatedTime": "30min",
+      "createdFrom": "plan",
+      "createdAt": "...",
+      "completedAt": "..."
+    }
+  ],
+  "statistics": {
+    "total": 5,
+    "pending": 1,
+    "in_progress": 0,
+    "completed": 3,
+    "cancelled": 1
+  }
+}
+```
+
+**用途**：
+- 📊 进度报告
+- 🔄 外部工具集成
+- 📝 项目文档
+- 💾 备份记录
+
+---
+
+#### `/todos clear`
+
+**功能**：清除所有 todos
+
+**语法**：
+```bash
+/todos clear
+```
+
+**效果**：
+- 删除内存中的所有 todos
+- 不影响 plan 数据
+
+**使用场景**：
+- 重新开始
+- 切换到其他计划
+
+---
+
+### 快捷键
+
+| 快捷键 | 功能 | 说明 |
+|--------|------|------|
+| `Ctrl+P` | 切换 Plan 模式 | 进入/退出 Plan 模式 |
+| `Ctrl+C` | 取消操作 | 取消当前执行 |
+| `Ctrl+D` | 退出 CLI | 退出 TianGong CLI |
+
+---
+
+## 使用场景
+
+### 场景 1：添加新功能
+
+**需求**：为博客系统添加评论功能
+
+#### Step 1: 规划
+
+```bash
+> [Ctrl+P]
+[PLAN] > 帮我规划如何为博客添加评论功能，包括评论、回复、点赞
+
+[AI 分析并创建计划...]
+
+✅ Plan Created: "Add Blog Comment System"
+
+Steps (6):
+1. step-1: Design comment data model
+2. step-2: Create comment API endpoints
+3. step-3: Implement comment storage
+4. step-4: Add reply functionality
+5. step-5: Implement like/unlike feature
+6. step-6: Create frontend components
+```
+
+#### Step 2: 转换并执行
+
+```bash
+> [Ctrl+P]  # 退出 Plan 模式
+> /plan to-todos
+✅ Created 6 todos
+
+> /todos list
+[查看列表]
+
+> /todos execute step-1 --mode=auto_edit
+[执行...]
+
+> /todos update step-1 completed
+> /todos execute step-2 --mode=default
+[逐步执行...]
+```
+
+---
+
+### 场景 2：代码重构
+
+**需求**：重构混乱的工具函数文件
+
+#### Step 1: 分析和规划
+
+```bash
+> [Ctrl+P]
+[PLAN] > 分析 utils.js 文件，规划如何将它重构为多个模块，保持向后兼容
+
+[AI 分析...]
+
+✅ Plan Created: "Refactor Utils Module"
+
+Steps (5):
+1. step-1: Analyze current utils.js dependencies
+2. step-2: Create new module structure
+3. step-3: Extract string utilities
+4. step-4: Extract date utilities
+5. step-5: Update imports with backwards compatibility
+```
+
+#### Step 2: 谨慎执行
+
+```bash
+> [Ctrl+P]
+> /plan to-todos
+
+# 重构需要谨慎，使用 default 模式
+> /todos execute step-1 --mode=default
+[仔细确认每个修改...]
+```
+
+---
+
+### 场景 3：学习和理解代码库
+
+**需求**：理解一个新接手的项目
+
+#### 只用 Plan 模式分析
+
+```bash
+> [Ctrl+P]
+[PLAN] > 分析这个项目的整体架构，包括：
+1. 项目结构
+2. 主要模块和职责
+3. 数据流
+4. 依赖关系
+
+[AI 深入分析...]
+
+✅ Plan Created: "Project Architecture Analysis"
+
+Steps (4):
+1. step-1: Understand directory structure
+2. step-2: Identify core modules
+3. step-3: Map data flow
+4. step-4: Document key dependencies
+
+[详细的分析结果...]
+```
+
+#### 不执行，只用于学习
+
+```bash
+> [Ctrl+P]  # 退出
+> /plan show  # 查看完整分析
+[仔细阅读...]
+
+# 不需要 to-todos，已经达到学习目的
+```
+
+---
+
+### 场景 4：数据库迁移
+
+**需求**：升级数据库 schema
+
+#### Step 1: 详细规划
+
+```bash
+> [Ctrl+P]
+[PLAN] > 规划如何将数据库从 v1 迁移到 v2，包括：
+- 迁移脚本
+- 数据备份
+- 回滚方案
+- 风险评估
+
+✅ Plan Created: "Database Migration v1 to v2"
+
+Steps (7):
+1. step-1: Create database backup
+2. step-2: Write migration script
+3. step-3: Write rollback script
+4. step-4: Test migration on staging
+5. step-5: Execute migration on production
+6. step-6: Verify data integrity
+7. step-7: Update application code
+
+Risks:
+⚠️  Data loss during migration
+⚠️  Downtime during migration
+⚠️  Incompatibility with existing data
+```
+
+#### Step 2: 仔细执行每一步
+
+```bash
+> [Ctrl+P]
+> /plan to-todos
+
+# 数据库操作必须使用 default 模式
+> /todos execute step-1 --mode=default
+[创建备份，仔细确认...]
+
+> /todos update step-1 completed
+
+# 继续下一步...
+```
+
+---
+
+### 场景 5：Bug 修复（不使用 Plan 模式）
+
+**需求**：修复一个已知的 bug
+
+#### 直接执行
+
+```bash
+# 对于简单 bug，不需要 Plan 模式
+> 修复 login.tsx 中的空指针错误，在第 45 行添加空值检查
+
+[AI 直接执行修复...]
+
+✓ edit login.tsx
+
+✅ Bug fixed!
+```
+
+**说明**：
+- 简单、明确的任务不需要 Plan+Todo
+- 直接执行更快更高效
+
+---
+
+## 最佳实践
+
+### 1. 何时使用 Plan 模式
+
+#### ✅ 推荐使用
+
+| 场景类型 | 说明 | 示例 |
+|---------|------|------|
+| 🏗️ 新功能开发 | 3 步以上的复杂功能 | 用户认证、支付集成 |
+| 🔄 代码重构 | 影响多个文件的重构 | 模块拆分、架构调整 |
+| 📚 学习代码 | 理解不熟悉的项目 | 新项目接手、技术栈学习 |
+| ⚠️ 高风险操作 | 需要风险评估的任务 | 数据库迁移、API 重构 |
+| 🎯 多步骤任务 | 有明确步骤的任务 | 部署流程、测试策略 |
+
+#### ❌ 不推荐使用
+
+| 场景类型 | 说明 | 替代方案 |
+|---------|------|----------|
+| 🐛 简单 Bug 修复 | 单文件、单行修复 | 直接执行 |
+| 📝 文档更新 | 添加/修改注释 | 直接执行 |
+| 🎨 样式调整 | CSS/样式微调 | 直接执行 |
+| ⚡ 紧急修复 | 生产环境紧急问题 | 直接执行 |
+
+### 2. 规划阶段最佳实践
+
+#### 提供充分的上下文
+
+**好的示例**：
+```bash
+[PLAN] > 这是一个使用 React + TypeScript + Express 的全栈项目。
+当前使用 JWT 认证。
+我想添加 OAuth 2.0 支持（Google 和 GitHub 登录）。
+请规划实现步骤，考虑向后兼容性。
+```
+
+**不好的示例**：
+```bash
+[PLAN] > 添加 OAuth
+# 缺少项目信息、技术栈、具体需求
+```
+
+#### 明确要求
+
+```bash
+[PLAN] > 规划实现用户权限系统，需要包括：
+1. 角色定义（管理员、编辑、读者）
+2. 权限检查中间件
+3. 前端权限控制
+4. 测试用例
+请给出详细的实现步骤和风险分析。
+```
+
+#### 审查计划
+
+使用 `/plan show` 仔细检查：
+- ✅ 步骤顺序是否合理？
+- ✅ 依赖关系是否正确？
+- ✅ 是否遗漏重要步骤？
+- ✅ 风险评估是否全面？
+- ✅ 测试策略是否充分？
+
+如果不满意，可以：
+```bash
+> /plan clear
+> [Ctrl+P]
+[PLAN] > 重新描述需求...
+```
+
+### 3. 执行阶段最佳实践
+
+#### 选择合适的执行模式
+
+**决策流程图**：
+
+```
+开始执行 todo
+    ↓
+这是核心业务逻辑吗？
+    ├─ 是 → 使用 default 模式 ⚠️
+    └─ 否
+        ↓
+    这是数据库操作吗？
+        ├─ 是 → 使用 default 模式 ⚠️
+        └─ 否
+            ↓
+        你完全信任 AI 的判断吗？
+            ├─ 是 → 可以使用 auto_edit 模式 ⚡
+            └─ 否 → 使用 default 模式 ⚠️
+```
+
+#### 逐步执行，及时更新
+
+**推荐流程**：
+```bash
+# 1. 执行一个 todo
+> /todos execute step-1 --mode=auto_edit
+
+# 2. 验证结果（手动检查或测试）
+# 查看修改的文件，运行测试...
+
+# 3. 更新状态
+> /todos update step-1 completed
+
+# 4. 查看列表，选择下一个
+> /todos list
+
+# 5. 重复步骤 1-4
+> /todos execute step-2 --mode=default
+```
+
+**不推荐**：
+```bash
+# ❌ 一次性执行所有，不验证
+> /todos execute step-1 --mode=auto_edit
+> /todos execute step-2 --mode=auto_edit
+> /todos execute step-3 --mode=auto_edit
+# 出错时难以定位问题
+```
+
+#### 处理依赖关系
+
+**自动检查**：
+```bash
+> /todos execute step-5
+
+❌ Dependencies not completed:
+- step-2
+- step-3
+```
+
+**正确处理**：
+```bash
+# 1. 检查哪些依赖未完成
+> /todos list
+
+# 2. 先完成依赖
+> /todos execute step-2
+> /todos update step-2 completed
+
+> /todos execute step-3
+> /todos update step-3 completed
+
+# 3. 现在可以执行了
+> /todos execute step-5
+```
+
+### 4. 进度管理最佳实践
+
+#### 定期查看进度
+
+```bash
+# 每完成几个 todo 后
+> /todos list
+
+📋 Progress:
+✅ 3 completed | 🔄 0 in progress | ⬜ 2 pending
+```
+
+#### 导出进度报告
+
+```bash
+# 阶段性导出
+> /todos export > progress-2025-10-16.json
+
+# 或复制输出到项目管理工具
+> /todos export
+[复制 JSON 内容...]
+```
+
+#### 处理问题任务
+
+```bash
+# 如果某个 todo 不再需要
+> /todos update step-4 cancelled
+
+# 如果需要重新执行
+> /todos update step-2 pending
+> /todos execute step-2 --mode=default
+```
+
+### 5. 团队协作最佳实践
+
+#### 分享计划
+
+```bash
+# 1. 创建计划后
+> /plan show > docs/implementation-plan.md
+
+# 2. 提交到代码库
+# git add docs/implementation-plan.md
+# git commit -m "Add implementation plan for feature X"
+```
+
+#### 分享进度
+
+```bash
+# 定期导出进度
+> /todos export > progress/week-42.json
+
+# 在团队会议上分享
+> /todos list
+[截图或共享屏幕]
+```
+
+#### 交接任务
+
+```bash
+# 导出当前状态
+> /todos export > handover.json
+
+# 新成员可以查看：
+# - 哪些已完成
+# - 哪些待执行
+# - 依赖关系
+# - 风险提示
+```
+
+---
+
+## 常见问题
+
+### 基础问题
+
+#### Q1: Plan+Todo 模式是什么？
+
+**A**: 一个两阶段的任务执行流程：
+1. **Plan 阶段**：AI 分析需求，创建详细计划（只读模式）
+2. **Todo 阶段**：将计划转为任务列表，逐步执行
+
+**优势**：先规划后执行，更安全、更有条理。
+
+---
+
+#### Q2: 为什么需要 Plan 模式？
+
+**A**: Plan 模式的价值：
+- 🔒 **安全**：只读模式，不会误操作
+- 🧠 **深思熟虑**：让 AI 先分析再动手
+- 📋 **结构化**：获得清晰的执行计划
+- ⚠️ **风险识别**：提前发现潜在问题
+- ✅ **质量保证**：包含测试策略
+
+**对比**：
+```bash
+# 传统方式
+> 添加用户登录功能
+[AI 直接开始修改代码...]
+[可能遗漏重要步骤]
+
+# Plan+Todo 方式
+> [Ctrl+P]
+[PLAN] > 规划用户登录功能
+[AI 先分析，创建完整计划]
+[你审查计划后再执行]
+```
+
+---
+
+#### Q3: 什么时候应该使用 Plan 模式？
+
+**A**: 适合场景：
+- ✅ 复杂的多步骤任务（3+ 步骤）
+- ✅ 跨多个文件/模块的功能
+- ✅ 需要风险评估的操作
+- ✅ 不熟悉的代码库
+- ✅ 重要的业务逻辑
+
+不需要场景：
+- ❌ 简单的单文件修改
+- ❌ 明确的小任务
+- ❌ 紧急 Bug 修复
+- ❌ 文档/注释更新
+
+---
+
+### 操作问题
+
+#### Q4: 如何进入和退出 Plan 模式？
+
+**A**: 使用 `Ctrl+P` 快捷键：
+
+```bash
+# 进入
+> [Ctrl+P]
+[PLAN] >  # 提示符变化
+
+# 退出
+[PLAN] > [Ctrl+P]
+>  # 提示符恢复
+```
+
+**提示**：
+- 进入 Plan 模式后，提示符会显示 `[PLAN]`
+- 可以随时按 `Ctrl+P` 切换
+
+---
+
+#### Q5: Todos 保存在哪里？会丢失吗？
+
+**A**: Todos 存储在**内存**中：
+- ✅ 当前会话中始终可用
+- ❌ 关闭 CLI 后会清空
+- 💾 可通过 `/todos export` 导出保存
+
+**如何备份**：
+```bash
+# 导出到文件
+> /todos export > backup.json
+
+# 或复制屏幕输出保存
+```
+
+---
+
+#### Q6: 如何修改或删除 Todo？
+
+**A**: 使用 `/todos update` 命令：
+
+```bash
+# 标记为已完成
+> /todos update step-1 completed
+
+# 取消不需要的任务
+> /todos update step-5 cancelled
+
+# 重置为待执行
+> /todos update step-2 pending
+
+# 清除所有
+> /todos clear
+```
+
+---
+
+#### Q7: 为什么我的 Todo 无法执行？
+
+**A**: 最常见原因是**依赖未完成**：
+
+```bash
+> /todos execute step-3
+
+❌ Dependencies not completed:
+- step-1
+- step-2
+```
+
+**解决方法**：
+1. 检查依赖：`/todos list`（查看 `[deps: ...]`）
+2. 先完成依赖的 todos
+3. 然后再执行当前 todo
+
+---
+
+### 模式和配置问题
+
+#### Q8: Default 和 Auto-edit 模式有什么区别？
+
+**A**: 
+
+| 特性 | Default 模式 | Auto-edit 模式 |
+|------|-------------|---------------|
+| **确认方式** | 每次操作需确认 | 自动批准 |
+| **安全性** | ⚠️ 高 | ⚡ 中 |
+| **速度** | 慢 | 快 |
+| **适用场景** | 核心逻辑、数据库 | UI、测试、文档 |
+| **命令** | `--mode=default` | `--mode=auto_edit` |
+
+**示例对比**：
+
+```bash
+# Default 模式
+> /todos execute step-1 --mode=default
+
+⚠️ write_file models/User.ts
+Confirm? (y/n): y  ← 需要确认
+
+✓ write_file models/User.ts
+```
+
+```bash
+# Auto-edit 模式
+> /todos execute step-1 --mode=auto_edit
+
+🟢 Auto-edit mode enabled
+
+✓ write_file models/User.ts (auto-approved)
+✓ edit database.ts (auto-approved)
+```
+
+---
+
+#### Q9: 可以同时执行多个 Todos 吗？
+
+**A**: 技术上可以，但**不推荐**：
+
+**不推荐**：
+```bash
+# ❌ 连续执行多个
+> /todos execute step-1 --mode=auto_edit
+> /todos execute step-2 --mode=auto_edit
+> /todos execute step-3 --mode=auto_edit
+```
+
+**推荐**：
+```bash
+# ✅ 逐个执行，验证后再继续
+> /todos execute step-1 --mode=auto_edit
+[验证结果...]
+> /todos update step-1 completed
+
+> /todos list  # 检查进度
+
+> /todos execute step-2 --mode=default
+[验证结果...]
+> /todos update step-2 completed
+```
+
+**原因**：
+- 便于发现问题
+- 及时验证结果
+- 依赖关系检查更准确
+
+---
+
+#### Q10: 可以修改 AI 创建的计划吗？
+
+**A**: 当前版本**不支持直接修改**计划，但可以：
+
+**方案 1：重新创建**
+```bash
+> /plan clear
+> [Ctrl+P]
+[PLAN] > 更详细地描述需求，明确你想要的改变
+```
+
+**方案 2：调整 Todos**
+```bash
+# 转换为 todos 后，可以：
+> /todos update step-3 cancelled  # 取消不需要的
+> /todos list  # 查看调整后的列表
+```
+
+**方案 3：分阶段执行**
+```bash
+# 只执行计划中你认可的部分
+> /todos execute step-1
+> /todos execute step-2
+# 跳过不需要的步骤
+```
+
+---
+
+### 高级问题
+
+#### Q11: Plan 模式下 AI 可以访问哪些工具？
+
+**A**: 
+
+**✅ 可以使用（只读工具）**：
+| 工具 | 说明 |
+|------|------|
+| `read_file` | 读取文件 |
+| `read_many_files` | 批量读取 |
+| `ls` | 列出目录 |
+| `grep`, `rg` | 搜索代码 |
+| `glob` | 查找文件 |
+| `web_fetch`, `web_search` | 查询资料 |
+| `create_plan` | **创建计划（核心）** |
+
+**❌ 不能使用（写工具）**：
+| 工具 | 说明 |
+|------|------|
+| `edit`, `smart_edit` | 编辑文件 |
+| `write_file` | 写文件 |
+| `run_shell_command` | 执行命令 |
+| 其他写操作 | 任何修改文件系统的操作 |
+
+---
+
+#### Q12: 如何查看 AI 创建计划时的分析过程？
+
+**A**: AI 在 Plan 模式下的思考过程会显示：
+
+```bash
+[PLAN] > 规划用户登录功能
+
+📖 Reading: src/auth/index.ts...
+📖 Reading: src/models/User.ts...
+🔍 Searching for: authentication patterns...
+📚 Analyzing: project structure...
+
+✅ Plan Created: "Implement User Login"
+[显示完整计划...]
+```
+
+**说明**：
+- AI 会显示正在读取的文件
+- 显示搜索和分析的内容
+- 最后输出结构化计划
+
+---
+
+#### Q13: 可以导出计划吗？
+
+**A**: 可以，有两种方式：
+
+**方式 1：查看并复制**
+```bash
+> /plan show
+[显示完整计划，可以复制]
+```
+
+**方式 2：保存为文件（通过 shell 重定向）**
+```bash
+# 需要在 CLI 外部使用
+# (计划功能，未来版本可能支持)
+```
+
+**当前最佳实践**：
+```bash
+> /plan show
+[手动复制内容到文档]
+# 或截图保存
+```
+
+---
+
+#### Q14: Todo 的优先级是如何确定的？
+
+**A**: 系统**自动分配**优先级，基于步骤顺序：
+
+| 步骤位置 | 优先级 | 说明 |
+|---------|--------|------|
+| 第 1-3 步 | **HIGH** | 最先执行 |
+| 第 4-6 步 | **MEDIUM** | 中等优先级 |
+| 第 7 步及之后 | **LOW** | 后续执行 |
+
+**示例**：
+```
+Plan 有 8 个步骤：
+- step-1, step-2, step-3 → HIGH
+- step-4, step-5, step-6 → MEDIUM
+- step-7, step-8 → LOW
+```
+
+**当前不支持手动调整优先级**
+
+---
+
+#### Q15: 如何处理长时间运行的 Todo？
+
+**A**: 对于长时间运行的任务：
+
+**建议 1：分解任务**
+```bash
+# 在 Plan 阶段要求分解
+[PLAN] > 规划数据库迁移，请将大任务分解为多个小步骤，
+每个步骤控制在 30 分钟内
+```
+
+**建议 2：监控执行**
+```bash
+# 执行时密切关注
+> /todos execute step-big-task --mode=default
+
+[AI 执行过程中会显示进度...]
+✓ Creating backup... (1/5)
+✓ Running migration script... (2/5)
+...
+```
+
+**建议 3：中断和恢复**
+```bash
+# 如果需要中断
+[Ctrl+C]  # 取消当前执行
+
+# 之后可以重新执行
+> /todos update step-big-task pending
+> /todos execute step-big-task --mode=default
+```
+
+---
+
+### 故障排除问题
+
+#### Q16: 按 Ctrl+P 没有反应？
+
+**A**: 可能的原因和解决方法：
+
+**原因 1：在补全模式下**
+```bash
+# Ctrl+P 可能被补全系统占用
+# 按 Esc 退出补全，然后再按 Ctrl+P
+```
+
+**原因 2：终端不支持**
+```bash
+# 某些终端可能不支持 Ctrl+P
+# 可以查看文档确认快捷键支持
+```
+
+**原因 3：已在 Plan 模式**
+```bash
+[PLAN] >  # 已经在 Plan 模式
+# 再按 Ctrl+P 会退出
+```
+
+---
+
+#### Q17: AI 创建的计划不符合预期怎么办？
+
+**A**: 可以采取以下措施：
+
+**方法 1：提供更多上下文**
+```bash
+> /plan clear
+> [Ctrl+P]
+[PLAN] > 这是一个 [技术栈] 项目，
+目前的架构是 [描述架构]，
+我想要 [详细需求]，
+请注意 [特殊要求]
+```
+
+**方法 2：明确不要什么**
+```bash
+[PLAN] > 规划用户认证功能，
+注意：不要使用 Session，必须使用 JWT
+```
+
+**方法 3：分步骤规划**
+```bash
+# 先规划总体
+[PLAN] > 概述实现用户系统需要哪些模块
+
+# 然后针对每个模块详细规划
+[PLAN] > 详细规划用户认证模块的实现
+```
+
+---
+
+#### Q18: 执行 Todo 时出错怎么办？
+
+**A**: 处理错误的步骤：
+
+**步骤 1：查看错误信息**
+```bash
+> /todos execute step-3
+
+❌ Error: File not found: src/models/User.ts
+
+# 仔细阅读错误信息
+```
+
+**步骤 2：标记为 Cancelled 或 Pending**
+```bash
+# 如果这个步骤不再需要
+> /todos update step-3 cancelled
+
+# 如果需要修复后重试
+> /todos update step-3 pending
+```
+
+**步骤 3：手动处理**
+```bash
+# 如果是简单问题，可以手动修复
+# 然后标记为完成
+> /todos update step-3 completed
+```
+
+**步骤 4：重新规划**
+```bash
+# 如果问题严重，重新规划
+> /plan clear
+> /todos clear
+> [Ctrl+P]
+[PLAN] > 重新描述需求，考虑之前的问题...
+```
+
+---
+
+#### Q19: 如何撤销 Todo 的执行？
+
+**A**: Todo 执行后**不支持自动撤销**，但可以：
+
+**方法 1：使用 Git 回滚**
+```bash
+# 查看改动
+git status
+git diff
+
+# 回滚文件
+git checkout -- <file>
+
+# 或回滚到之前的提交
+git reset --hard HEAD~1
+```
+
+**方法 2：手动修复**
+```bash
+# 使用 TianGong CLI 修复
+> 撤销刚才对 User.ts 的修改
+```
+
+**方法 3：重新执行计划**
+```bash
+# 从头开始
+> /plan clear
+> /todos clear
+> [Ctrl+P]
+[PLAN] > 重新规划...
+```
+
+**预防措施**：
+- 使用 `--mode=default` 仔细审查
+- 定期 Git 提交
+- 在非关键环境测试
+
+---
+
+#### Q20: Todos 消失了怎么办？
+
+**A**: Todos 存储在内存中，以下情况会丢失：
+
+**会丢失的情况**：
+- ❌ 关闭 CLI
+- ❌ CLI 崩溃
+- ❌ 执行 `/todos clear`
+
+**如何预防**：
+```bash
+# 定期导出备份
+> /todos export > backup-$(date +%Y%m%d-%H%M%S).json
+```
+
+**如何恢复**：
+```bash
+# 如果有 Plan，重新转换
+> /plan to-todos
+
+# 或重新进入 Plan 模式创建
+> [Ctrl+P]
+[PLAN] > [描述任务]
+```
+
+---
+
+## 故障排除
+
+### 常见错误及解决方案
+
+#### 错误 1：依赖未完成
+
+**错误信息**：
+```bash
+> /todos execute step-3
+
+❌ Cannot execute step-3. Dependencies not completed:
+- step-1
+- step-2
+
+Complete dependencies first.
+```
+
+**原因**：step-3 依赖 step-1 和 step-2，但它们还没有完成。
+
+**解决方案**：
+```bash
+# 1. 查看 todo 列表
+> /todos list
+
+# 2. 找到依赖的 todos
+⬜ step-1 - ...
+⬜ step-2 - ...
+
+# 3. 先执行依赖
+> /todos execute step-1
+> /todos update step-1 completed
+
+> /todos execute step-2
+> /todos update step-2 completed
+
+# 4. 现在可以执行 step-3
+> /todos execute step-3
+```
+
+---
+
+#### 错误 2：Todo 不存在
+
+**错误信息**：
+```bash
+> /todos execute step-10
+
+❌ Todo 'step-10' not found.
+
+Use /todos list to see available todos.
+```
+
+**原因**：输入的 todo ID 不存在。
+
+**解决方案**：
+```bash
+# 1. 查看正确的 ID
+> /todos list
+
+📋 Todo List:
+⬜ step-1 - ...
+⬜ step-2 - ...
+
+# 2. 使用正确的 ID
+> /todos execute step-1
+```
+
+---
+
+#### 错误 3：没有活动的计划
+
+**错误信息**：
+```bash
+> /plan to-todos
+
+❌ No active plan found.
+
+Create a plan first:
+1. Enter Plan mode: Ctrl+P
+2. Ask AI to create a plan
+3. AI will call create_plan tool
+```
+
+**原因**：还没有创建计划。
+
+**解决方案**：
+```bash
+# 1. 进入 Plan 模式
+> [Ctrl+P]
+
+# 2. 创建计划
+[PLAN] > 规划...
+
+# 3. 退出 Plan 模式
+> [Ctrl+P]
+
+# 4. 现在可以转换
+> /plan to-todos
+```
+
+---
+
+#### 错误 4：无效的状态
+
+**错误信息**：
+```bash
+> /todos update step-1 finished
+
+❌ Invalid status 'finished'.
+Must be one of: pending, in_progress, completed, cancelled
+```
+
+**原因**：使用了不支持的状态名称。
+
+**解决方案**：
+```bash
+# 使用正确的状态
+> /todos update step-1 completed
+
+# 支持的状态：
+# - pending
+# - in_progress
+# - completed
+# - cancelled
+```
+
+---
+
+### 性能和体验问题
+
+#### 问题 1：AI 响应很慢
+
+**可能原因**：
+- 网络延迟
+- 模型负载高
+- 分析的文件过多
+
+**解决方案**：
+```bash
+# 1. 缩小分析范围
+[PLAN] > 只分析 src/auth 目录，规划...
+
+# 2. 明确指定文件
+[PLAN] > 查看 src/models/User.ts 和 src/auth/jwt.ts，
+然后规划...
+
+# 3. 等待或重试
+# 如果长时间无响应，按 Ctrl+C 取消，然后重试
+```
+
+---
+
+#### 问题 2：Plan 太简单或太复杂
+
+**太简单**：
+```bash
+✅ Plan Created: "Add Feature"
+
+Steps (2):
+1. step-1: Implement feature
+2. step-2: Test feature
+```
+
+**解决方案**：
+```bash
+> /plan clear
+> [Ctrl+P]
+[PLAN] > 请详细规划，分解为具体的小步骤，
+每个步骤说明需要修改哪些文件，
+包括详细的风险分析和测试策略
+```
+
+**太复杂**：
+```bash
+✅ Plan Created: "Add Feature"
+
+Steps (20):
+[太多步骤...]
+```
+
+**解决方案**：
+```bash
+> /plan clear
+> [Ctrl+P]
+[PLAN] > 请创建高层次的规划，
+主要步骤控制在 5-8 个，
+每个步骤是一个独立的功能模块
+```
+
+---
+
+### 获取帮助
+
+#### 内置帮助
+
+```bash
+# 查看所有命令
+> /help
+
+# 查看特定命令帮助
+> /help plan
+> /help todos
+```
+
+#### 文档
+
+- 📖 用户手册（本文档）
+- 📋 快速开始指南
+- 🛠️ 开发者文档
+
+#### 社区支持
+
+- 💬 GitHub Issues
+- 📧 邮件支持
+- 💡 功能建议
+
+---
+
+## 附录
+
+### A. 命令速查表
+
+#### 基本操作
+
+| 操作 | 命令/快捷键 |
+|------|------------|
+| 进入 Plan 模式 | `Ctrl+P` |
+| 退出 Plan 模式 | `Ctrl+P` |
+| 取消当前操作 | `Ctrl+C` |
+| 退出 CLI | `Ctrl+D` |
+
+#### Plan 命令
+
+| 命令 | 说明 |
+|------|------|
+| `/plan show` | 显示当前计划 |
+| `/plan to-todos` | 转换为 todos |
+| `/plan clear` | 清除计划 |
+
+#### Todo 命令
+
+| 命令 | 说明 |
+|------|------|
+| `/todos list` | 列出所有 todos |
+| `/todos execute <id>` | 执行单个 todo（default 模式） |
+| `/todos execute <id> --mode=auto_edit` | 执行单个 todo（auto-edit 模式） |
+| `/todos execute-all` | 批量执行所有待执行 todos（default 模式） |
+| `/todos execute-all --mode=auto_edit` | 批量执行所有待执行 todos（auto-edit 模式） |
+| `/todos update <id> <status>` | 更新 todo 状态 |
+| `/todos export` | 导出为 JSON |
+| `/todos clear` | 清除所有 todos |
+
+---
+
+### B. 状态和优先级
+
+#### Todo 状态
+
+| 状态 | 图标 | 英文 | 说明 |
+|------|------|------|------|
+| 待执行 | ⬜ | `pending` | 默认状态 |
+| 执行中 | 🔄 | `in_progress` | 自动设置 |
+| 已完成 | ✅ | `completed` | 任务完成 |
+| 已取消 | ❌ | `cancelled` | 不再需要 |
+
+#### 优先级分配
+
+| 优先级 | 步骤范围 |
+|--------|---------|
+| HIGH | 第 1-3 步 |
+| MEDIUM | 第 4-6 步 |
+| LOW | 第 7 步及之后 |
+
+---
+
+### C. 示例模板
+
+#### 功能开发模板
+
+```bash
+> [Ctrl+P]
+[PLAN] > 规划实现 [功能名称] 功能
+
+要求：
+1. 分析现有 [相关模块] 的代码
+2. 考虑与 [其他功能] 的集成
+3. 包含完整的错误处理
+4. 提供测试策略
+5. 评估潜在风险
+
+技术栈：[列出技术栈]
+时间限制：[如果有]
+```
+
+#### 重构模板
+
+```bash
+> [Ctrl+P]
+[PLAN] > 规划重构 [模块名称]
+
+当前问题：
+- [列出当前存在的问题]
+
+期望结果：
+- [列出期望达到的目标]
+
+约束条件：
+- 保持向后兼容
+- 不影响现有功能
+- [其他约束]
+
+请提供详细的重构步骤和风险评估
+```
+
+#### 学习分析模板
+
+```bash
+> [Ctrl+P]
+[PLAN] > 分析 [项目/模块] 的架构和实现
+
+请帮我理解：
+1. 整体架构和模块划分
+2. 核心功能实现原理
+3. 数据流和依赖关系
+4. 关键设计决策
+5. 潜在的改进点
+
+不需要生成可执行的步骤，只需要分析和文档
+```
+
+---
+
+### D. 术语表
+
+| 术语 | 说明 |
+|------|------|
+| **Plan 模式** | 只读的规划模式，AI 分析并创建计划 |
+| **Todo** | 从 Plan 转换的可执行任务 |
+| **依赖** | Todo 之间的前置条件关系 |
+| **Default 模式** | 需要确认的执行模式 |
+| **Auto-edit 模式** | 自动批准的执行模式 |
+| **优先级** | Todo 的重要程度（HIGH/MEDIUM/LOW） |
+| **状态** | Todo 的执行状态（pending/in_progress/completed/cancelled） |
+| **只读工具** | Plan 模式下可用的不修改代码的工具 |
+| **写工具** | Plan 模式下不可用的会修改代码的工具 |
+
+---
+
+## 结语
+
+恭喜！您已经掌握了 TianGong CLI 的 Plan+Todo 模式。
+
+### 核心要点回顾
+
+1. 📋 **Plan 阶段**：使用 `Ctrl+P` 进入 Plan 模式，让 AI 创建详细规划
+2. ✅ **Todo 阶段**：使用 `/plan to-todos` 转换，用 `/todos execute` 逐步执行
+3. ⚙️ **执行控制**：根据任务重要性选择 `default` 或 `auto_edit` 模式
+4. 🔗 **依赖管理**：系统自动检查和验证任务依赖关系
+5. 📊 **进度追踪**：使用 `/todos list` 查看进度，`/todos export` 导出报告
+
+### 下一步
+
+- 🚀 立即尝试：按 `Ctrl+P` 开始您的第一个计划
+- 📖 深入学习：查看更多示例和最佳实践
+- 💡 分享反馈：帮助我们改进 Plan+Todo 模式
+
+**祝您使用愉快！**
+
+---
+
+*文档版本：1.0*  
+*最后更新：2025-10-16*  
+*TianGong CLI Plan+Todo 模式使用手册*
+
+

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -37,6 +37,8 @@ import { terminalSetupCommand } from '../ui/commands/terminalSetupCommand.js';
 import { modelCommand } from '../ui/commands/modelCommand.js';
 import { agentsCommand } from '../ui/commands/agentsCommand.js';
 import { workflowCommand } from '../ui/commands/workflowCommand.js';
+import { planCommand } from '../ui/commands/planCommand.js';
+import { todosCommand } from '../ui/commands/todosCommand.js';
 
 /**
  * Loads the core, hard-coded slash commands that are an integral part
@@ -73,11 +75,13 @@ export class BuiltinCommandLoader implements ICommandLoader {
       mcpCommand,
       memoryCommand,
       modelCommand,
+      planCommand,
       privacyCommand,
       quitCommand,
       restoreCommand(this.config),
       statsCommand,
       themeCommand,
+      todosCommand,
       toolsCommand,
       settingsCommand,
       vimCommand,

--- a/packages/cli/src/types/plan.ts
+++ b/packages/cli/src/types/plan.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { PlanStep } from '@google/gemini-cli-core';
+
+/**
+ * Plan data structure stored in session
+ */
+export interface PlanData {
+  title: string;
+  overview: string;
+  steps: PlanStep[];
+  risks?: string[];
+  testingStrategy?: string;
+  estimatedDuration?: string;
+  createdAt: Date;
+}
+
+

--- a/packages/cli/src/ui/commands/planCommand.ts
+++ b/packages/cli/src/ui/commands/planCommand.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SlashCommand, CommandContext } from './types.js';
+import { CommandKind } from './types.js';
+import { MessageType } from '../types.js';
+import { planToTodos } from '../../utils/todoUtils.js';
+
+export const planCommand: SlashCommand = {
+  name: 'plan',
+  description: 'Plan mode management - show, convert to todos',
+  kind: CommandKind.BUILT_IN,
+  subCommands: [
+    {
+      name: 'to-todos',
+      description: 'Convert current plan to todo list (in memory)',
+      kind: CommandKind.BUILT_IN,
+      action: async (context: CommandContext) => {
+        const plan = (context.session as any).currentPlan;
+
+        if (!plan) {
+          context.ui.addItem(
+            {
+              type: MessageType.ERROR,
+              text: 'No active plan found.\n\nCreate a plan first:\n1. Enter Plan mode: Ctrl+P\n2. Ask AI to create a plan\n3. AI will call create_plan tool',
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        // Convert plan to todos
+        const todos = planToTodos(plan);
+
+        // Store in session
+        if (typeof (context.session as any).setTodos === 'function') {
+          (context.session as any).setTodos(todos);
+        }
+
+        context.ui.addItem(
+          {
+            type: MessageType.INFO,
+            text:
+              `✅ **Created ${todos.length} todos from plan** "${plan.title}"\n\n` +
+              `💡 Next steps:\n` +
+              `- /todos list - View all todos\n` +
+              `- /todos execute <id> [--mode=auto_edit|default] - Execute a todo\n` +
+              `- /todos execute-all [--mode=auto_edit|default] - Execute all\n` +
+              `- /todos export - Export to JSON`,
+          },
+          Date.now(),
+        );
+      },
+    },
+
+    {
+      name: 'show',
+      description: 'Show current plan',
+      kind: CommandKind.BUILT_IN,
+      action: async (context: CommandContext) => {
+        const plan = (context.session as any).currentPlan;
+
+        if (!plan) {
+          context.ui.addItem(
+            {
+              type: MessageType.INFO,
+              text: 'No active plan.\n\n💡 Enter Plan mode (Ctrl+P) and ask AI to create a plan.',
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        let output = `# 📋 ${plan.title}\n\n`;
+        output += `**Overview**: ${plan.overview}\n\n`;
+        output += `## 🔢 Steps (${plan.steps.length})\n\n`;
+
+        plan.steps.forEach((step: any, idx: number) => {
+          output += `${idx + 1}. **${step.id}**: ${step.description}\n`;
+          
+          if (step.module) {
+            output += `   - 📦 Module: ${step.module}\n`;
+          }
+          
+          if (step.dependencies && step.dependencies.length > 0) {
+            output += `   - 🔗 Depends on: ${step.dependencies.join(', ')}\n`;
+          }
+          
+          if (step.risks && step.risks.length > 0) {
+            output += `   - ⚠️  Risks: ${step.risks.join(', ')}\n`;
+          }
+          
+          if (step.estimatedTime) {
+            output += `   - ⏱️  Estimated: ${step.estimatedTime}\n`;
+          }
+          
+          output += '\n';
+        });
+
+        if (plan.risks && plan.risks.length > 0) {
+          output += `## ⚠️ Overall Risks\n\n`;
+          plan.risks.forEach((r: string) => (output += `- ${r}\n`));
+          output += '\n';
+        }
+
+        if (plan.testingStrategy) {
+          output += `## ✅ Testing Strategy\n\n${plan.testingStrategy}\n\n`;
+        }
+
+        if (plan.estimatedDuration) {
+          output += `## ⏱️ Estimated Duration\n\n${plan.estimatedDuration}\n\n`;
+        }
+
+        output += `💡 Convert to todos: /plan to-todos`;
+
+        context.ui.addItem(
+          {
+            type: MessageType.INFO,
+            text: output,
+          },
+          Date.now(),
+        );
+      },
+    },
+
+    {
+      name: 'clear',
+      description: 'Clear current plan',
+      kind: CommandKind.BUILT_IN,
+      action: async (context: CommandContext) => {
+        if (typeof (context.session as any).setCurrentPlan === 'function') {
+          (context.session as any).setCurrentPlan(null);
+        }
+
+        context.ui.addItem(
+          {
+            type: MessageType.INFO,
+            text: '✅ Plan cleared',
+          },
+          Date.now(),
+        );
+      },
+    },
+  ],
+};
+

--- a/packages/cli/src/ui/commands/todosCommand.ts
+++ b/packages/cli/src/ui/commands/todosCommand.ts
@@ -1,0 +1,464 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SlashCommand, CommandContext } from './types.js';
+import { CommandKind } from './types.js';
+import { MessageType } from '../types.js';
+import {
+  formatTodosDisplay,
+  checkDependencies,
+  exportTodosToJson,
+} from '../../utils/todoUtils.js';
+import { ApprovalMode } from '@google/gemini-cli-core';
+
+export const todosCommand: SlashCommand = {
+  name: 'todos',
+  description: 'Manage in-memory todo list - list, execute, update, export',
+  kind: CommandKind.BUILT_IN,
+  subCommands: [
+    {
+      name: 'list',
+      description: 'List all todos',
+      kind: CommandKind.BUILT_IN,
+      action: async (context: CommandContext, args?: string) => {
+        const todos = (context.session as any).todos || [];
+
+        if (todos.length === 0) {
+          context.ui.addItem(
+            {
+              type: MessageType.INFO,
+              text:
+                'No todos yet.\n\n' +
+                '💡 To create todos:\n' +
+                '1. Enter Plan mode: Ctrl+P\n' +
+                '2. Ask AI to plan a task\n' +
+                '3. Convert plan: /plan to-todos',
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        // Display formatted todo list
+        const output = formatTodosDisplay(todos);
+        context.ui.addItem(
+          {
+            type: MessageType.INFO,
+            text: output,
+          },
+          Date.now(),
+        );
+      },
+    },
+
+    {
+      name: 'execute',
+      description: 'Execute a single todo: /todos execute <id> [--mode=auto_edit|default]',
+      kind: CommandKind.BUILT_IN,
+      action: async (context: CommandContext, args?: string) => {
+        if (!args || args.trim() === '') {
+          context.ui.addItem(
+            {
+              type: MessageType.ERROR,
+              text:
+                'Usage: /todos execute <id> [--mode=auto_edit|default]\n\n' +
+                'Examples:\n' +
+                '  /todos execute step-1\n' +
+                '  /todos execute step-2 --mode=auto_edit',
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        const todos = (context.session as any).todos || [];
+
+        if (todos.length === 0) {
+          context.ui.addItem(
+            {
+              type: MessageType.ERROR,
+              text: 'No todos to execute. Create todos first with /plan to-todos',
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        // Parse arguments
+        const parts = args.trim().split(/\s+/);
+        const todoId = parts[0];
+        const modeMatch = args.match(/--mode=(auto_edit|default)/);
+        const approvalMode = modeMatch ? modeMatch[1] : 'default';
+
+        // Find todo
+        const todo = todos.find((t: any) => t.id === todoId);
+        if (!todo) {
+          context.ui.addItem(
+            {
+              type: MessageType.ERROR,
+              text: `Todo '${todoId}' not found.\n\nUse /todos list to see available todos.`,
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        // Check dependencies
+        const depCheck = checkDependencies(todo, todos);
+        if (!depCheck.satisfied) {
+          context.ui.addItem(
+            {
+              type: MessageType.ERROR,
+              text:
+                `❌ Cannot execute ${todoId}. Dependencies not completed:\n` +
+                depCheck.incomplete.map(d => `- ${d}`).join('\n') +
+                `\n\nComplete dependencies first.`,
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        // Save original approval mode
+        const originalMode = context.services.config!.getApprovalMode();
+
+        try {
+          // Set approval mode for this execution
+          if (approvalMode === 'auto_edit') {
+            context.services.config!.setApprovalMode(ApprovalMode.AUTO_EDIT);
+            context.ui.addItem(
+              {
+                type: MessageType.INFO,
+                text: '🟢 Auto-edit mode enabled for this task',
+              },
+              Date.now(),
+            );
+          }
+
+          // Show execution info
+          let execInfo = `🔄 **Executing**: ${todo.description}\n\n`;
+          execInfo += `📌 ID: ${todo.id}\n`;
+          execInfo += `⚙️ Approval mode: ${approvalMode}\n`;
+          
+          if (todo.module) {
+            execInfo += `📦 Module: ${todo.module}\n`;
+          }
+          
+          if (todo.risks && todo.risks.length > 0) {
+            execInfo += `⚠️  Risks: ${todo.risks.join(', ')}\n`;
+          }
+          
+          if (todo.estimatedTime) {
+            execInfo += `⏱️  Estimated: ${todo.estimatedTime}\n`;
+          }
+
+          context.ui.addItem(
+            {
+              type: MessageType.INFO,
+              text: execInfo,
+            },
+            Date.now(),
+          );
+
+          // Update status to in_progress
+          if (typeof (context.session as any).updateTodo === 'function') {
+            (context.session as any).updateTodo(todoId, {
+              status: 'in_progress',
+            });
+          }
+
+          // Build execution prompt
+          const plan = (context.session as any).currentPlan;
+          let prompt = `Execute this task: ${todo.description}\n\n`;
+          
+          if (plan) {
+            prompt += `Context from plan: ${plan.overview}\n\n`;
+          }
+          
+          if (todo.risks && todo.risks.length > 0) {
+            prompt += `⚠️ Risks to consider:\n${todo.risks.map((r: string) => `- ${r}`).join('\n')}\n\n`;
+          }
+          
+          prompt += `Complete this task thoroughly and report when done.`;
+
+          // Return prompt to be submitted to Gemini
+          return {
+            type: 'submit_prompt',
+            content: prompt,
+          };
+
+        } finally {
+          // Note: Approval mode will be restored after execution completes
+          // We'll do this in a follow-up message handler
+          setTimeout(() => {
+            context.services.config!.setApprovalMode(originalMode);
+          }, 100);
+        }
+      },
+    },
+
+    {
+      name: 'update',
+      description: 'Update todo status: /todos update <id> <status>',
+      kind: CommandKind.BUILT_IN,
+      action: async (context: CommandContext, args?: string) => {
+        const parts = args?.trim().split(/\s+/) || [];
+        const [id, status] = parts;
+
+        if (!id || !status) {
+          context.ui.addItem(
+            {
+              type: MessageType.ERROR,
+              text:
+                'Usage: /todos update <id> <status>\n\n' +
+                'Status options:\n' +
+                '  - pending\n' +
+                '  - in_progress\n' +
+                '  - completed\n' +
+                '  - cancelled\n\n' +
+                'Example: /todos update step-1 completed',
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        const validStatuses = ['pending', 'in_progress', 'completed', 'cancelled'];
+        if (!validStatuses.includes(status)) {
+          context.ui.addItem(
+            {
+              type: MessageType.ERROR,
+              text: `Invalid status '${status}'.\nMust be one of: ${validStatuses.join(', ')}`,
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        const todos = (context.session as any).todos || [];
+        const todo = todos.find((t: any) => t.id === id);
+
+        if (!todo) {
+          context.ui.addItem(
+            {
+              type: MessageType.ERROR,
+              text: `Todo '${id}' not found.\n\nUse /todos list to see available todos.`,
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        // Update todo
+        if (typeof (context.session as any).updateTodo === 'function') {
+          const updates: any = { status };
+          
+          if (status === 'completed') {
+            updates.completedAt = new Date();
+          }
+          
+          (context.session as any).updateTodo(id, updates);
+        }
+
+        context.ui.addItem(
+          {
+            type: MessageType.INFO,
+            text:
+              `✅ Updated \`${id}\` → **${status}**\n\n` +
+              `Current todo list:\n\n` +
+              formatTodosDisplay((context.session as any).todos || []),
+          },
+          Date.now(),
+        );
+      },
+    },
+
+    {
+      name: 'export',
+      description: 'Export todos to JSON format',
+      kind: CommandKind.BUILT_IN,
+      action: async (context: CommandContext) => {
+        const todos = (context.session as any).todos || [];
+        const plan = (context.session as any).currentPlan;
+
+        if (todos.length === 0) {
+          context.ui.addItem(
+            {
+              type: MessageType.INFO,
+              text: 'No todos to export.',
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        const json = exportTodosToJson(todos, plan);
+
+        context.ui.addItem(
+          {
+            type: MessageType.INFO,
+            text:
+              `📄 **Todos JSON Export**\n\n` +
+              `\`\`\`json\n${json}\n\`\`\`\n\n` +
+              `💡 Copy this JSON for:\n` +
+              `- External automation tools\n` +
+              `- Project management systems\n` +
+              `- Progress tracking`,
+          },
+          Date.now(),
+        );
+      },
+    },
+
+    {
+      name: 'execute-all',
+      description: 'Execute all pending todos in order: /todos execute-all [--mode=auto_edit|default]',
+      kind: CommandKind.BUILT_IN,
+      action: async (context: CommandContext, args?: string) => {
+        const todos = (context.session as any).todos || [];
+        
+        if (todos.length === 0) {
+          context.ui.addItem(
+            {
+              type: MessageType.ERROR,
+              text: 'No todos to execute. Create todos first with /plan to-todos',
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        // Parse mode argument
+        const modeMatch = args?.match(/--mode=(auto_edit|default)/);
+        const mode = modeMatch ? modeMatch[1] : 'default';
+
+        // Get pending todos count
+        const pendingTodos = todos.filter((t: any) => t.status === 'pending');
+        
+        if (pendingTodos.length === 0) {
+          context.ui.addItem(
+            {
+              type: MessageType.INFO,
+              text: '✅ All todos are already completed or in progress.\n\nUse /todos list to see status.',
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        // Find first executable todo
+        const { getNextExecutableTodo } = await import('../../utils/todoUtils.js');
+        const nextTodo = getNextExecutableTodo(todos);
+        
+        if (!nextTodo) {
+          context.ui.addItem(
+            {
+              type: MessageType.ERROR,
+              text: '❌ No executable todos found.\n\nAll pending todos have unsatisfied dependencies.',
+            },
+            Date.now(),
+          );
+          return;
+        }
+
+        // Initialize execution queue
+        const setExecutionQueue = (context.session as any).setExecutionQueue;
+        if (typeof setExecutionQueue === 'function') {
+          setExecutionQueue({
+            active: true,
+            mode: mode as 'default' | 'auto_edit',
+            currentIndex: 1,
+            totalCount: pendingTodos.length,
+            executingTodoId: nextTodo.id,
+          });
+        }
+
+        // Display batch execution start message
+        context.ui.addItem(
+          {
+            type: MessageType.INFO,
+            text:
+              `🚀 **Starting Batch Execution**\n\n` +
+              `📊 Total todos: ${pendingTodos.length}\n` +
+              `⚙️ Approval mode: ${mode}\n` +
+              `🎯 First todo: ${nextTodo.description}\n\n` +
+              `💡 Press Ctrl+C to stop at any time`,
+          },
+          Date.now(),
+        );
+
+        // Save original approval mode
+        const { ApprovalMode } = await import('@google/gemini-cli-core');
+        const originalMode = context.services.config!.getApprovalMode();
+
+        try {
+          // Set approval mode for batch execution
+          if (mode === 'auto_edit') {
+            context.services.config!.setApprovalMode(ApprovalMode.AUTO_EDIT);
+          }
+
+          // Update status to in_progress
+          const updateTodo = (context.session as any).updateTodo;
+          if (typeof updateTodo === 'function') {
+            updateTodo(nextTodo.id, { status: 'in_progress' });
+          }
+
+          // Build execution prompt for first todo
+          const plan = (context.session as any).currentPlan;
+          let prompt = `[Batch Execution 1/${pendingTodos.length}] ${nextTodo.description}\n\n`;
+          
+          if (plan) {
+            prompt += `Context from plan: ${plan.overview}\n\n`;
+          }
+          
+          if (nextTodo.risks && nextTodo.risks.length > 0) {
+            prompt += `⚠️ Risks to consider:\n${nextTodo.risks.map((r: string) => `- ${r}`).join('\n')}\n\n`;
+          }
+          
+          prompt += `Complete this task thoroughly and report when done.`;
+
+          // Return prompt to be submitted to Gemini
+          return {
+            type: 'submit_prompt',
+            content: prompt,
+          };
+
+        } catch (error) {
+          // Restore original approval mode on error
+          context.services.config!.setApprovalMode(originalMode);
+          
+          // Clear execution queue
+          const setExecutionQueue = (context.session as any).setExecutionQueue;
+          if (typeof setExecutionQueue === 'function') {
+            setExecutionQueue(null);
+          }
+
+          throw error;
+        }
+      },
+    },
+
+    {
+      name: 'clear',
+      description: 'Clear all todos',
+      kind: CommandKind.BUILT_IN,
+      action: async (context: CommandContext) => {
+        if (typeof (context.session as any).setTodos === 'function') {
+          (context.session as any).setTodos([]);
+        }
+
+        context.ui.addItem(
+          {
+            type: MessageType.INFO,
+            text: '✅ All todos cleared',
+          },
+          Date.now(),
+        );
+      },
+    },
+  ],
+};
+

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -142,6 +142,7 @@ export const Composer = () => {
           focus={true}
           vimHandleInput={uiActions.vimHandleInput}
           isEmbeddedShellFocused={uiState.embeddedShellFocused}
+          planModeActive={uiState.planModeActive}
           placeholder={
             vimEnabled
               ? "  Press 'i' for INSERT mode and 'Esc' for NORMAL mode."

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -71,6 +71,7 @@ export interface InputPromptProps {
   onEscapePromptChange?: (showPrompt: boolean) => void;
   vimHandleInput?: (key: Key) => boolean;
   isEmbeddedShellFocused?: boolean;
+  planModeActive?: boolean;
 }
 
 // The input content, input container, and input suggestions list may have different widths
@@ -107,6 +108,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   onEscapePromptChange,
   vimHandleInput,
   isEmbeddedShellFocused,
+  planModeActive,
 }) => {
   const kittyProtocol = useKittyKeyboardProtocol();
   const isShellFocused = useShellFocusState();
@@ -889,7 +891,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           color={statusColor ?? theme.text.accent}
           aria-label={statusText || undefined}
         >
-          {shellModeActive ? (
+          {planModeActive ? (
+            <Text color={theme.text.accent}>[PLAN] {'>'}</Text>
+          ) : shellModeActive ? (
             reverseSearchActive ? (
               <Text
                 color={theme.text.link}

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -120,6 +120,7 @@ export interface UIState {
   activePtyId: number | undefined;
   embeddedShellFocused: boolean;
   showDebugProfiler: boolean;
+  planModeActive: boolean;
 }
 
 export const UIStateContext = createContext<UIState | null>(null);

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -72,6 +72,22 @@ export const useSlashCommandProcessor = (
   actions: SlashCommandProcessorActions,
   extensionsUpdateState: Map<string, ExtensionUpdateStatus>,
   isConfigInitialized: boolean,
+  planTodoState?: {
+    todos: any[];
+    setTodos: (todos: any[]) => void;
+    updateTodo: (id: string, updates: any) => void;
+    currentPlan: any;
+    setCurrentPlan: (plan: any) => void;
+    planModeActive: boolean;
+    executionQueue: {
+      active: boolean;
+      mode: 'default' | 'auto_edit';
+      currentIndex: number;
+      totalCount: number;
+      executingTodoId: string | null;
+    } | null;
+    setExecutionQueue: (queue: any) => void;
+  },
 ) => {
   const session = useSessionStats();
   const [commands, setCommands] = useState<readonly SlashCommand[]>([]);
@@ -210,7 +226,8 @@ export const useSlashCommandProcessor = (
       session: {
         stats: session.stats,
         sessionShellAllowlist,
-      },
+        ...(planTodoState || {}),
+      } as any,
     }),
     [
       config,
@@ -230,6 +247,7 @@ export const useSlashCommandProcessor = (
       setGeminiMdFileCount,
       reloadCommands,
       extensionsUpdateState,
+      planTodoState,
     ],
   );
 

--- a/packages/cli/src/utils/todoUtils.ts
+++ b/packages/cli/src/utils/todoUtils.ts
@@ -1,0 +1,199 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ExtendedTodo, TodoStatus, TodoPriority } from '@google/gemini-cli-core';
+import type { PlanData } from '../types/plan.js';
+
+/**
+ * Format todos for display
+ */
+export function formatTodosDisplay(todos: ExtendedTodo[]): string {
+  if (todos.length === 0) {
+    return '📋 No todos';
+  }
+
+  const stats = {
+    total: todos.length,
+    pending: todos.filter(t => t.status === 'pending').length,
+    in_progress: todos.filter(t => t.status === 'in_progress').length,
+    completed: todos.filter(t => t.status === 'completed').length,
+    cancelled: todos.filter(t => t.status === 'cancelled').length,
+  };
+
+  let output = `📋 **Todo List** (${stats.total} total)\n\n`;
+  output += `✅ ${stats.completed} completed | `;
+  output += `🔄 ${stats.in_progress} in progress | `;
+  output += `⬜ ${stats.pending} pending | `;
+  output += `❌ ${stats.cancelled} cancelled\n\n`;
+
+  // Group by priority (only show active todos)
+  const byPriority = {
+    high: todos.filter(
+      t =>
+        t.priority === 'high' &&
+        t.status !== 'completed' &&
+        t.status !== 'cancelled',
+    ),
+    medium: todos.filter(
+      t =>
+        t.priority === 'medium' &&
+        t.status !== 'completed' &&
+        t.status !== 'cancelled',
+    ),
+    low: todos.filter(
+      t =>
+        t.priority === 'low' &&
+        t.status !== 'completed' &&
+        t.status !== 'cancelled',
+    ),
+  };
+
+  for (const [priority, items] of Object.entries(byPriority)) {
+    if (items.length === 0) continue;
+
+    output += `### ${priority.toUpperCase()} Priority\n\n`;
+    for (const todo of items) {
+      const icon = getStatusIcon(todo.status);
+      output += `${icon} \`${todo.id}\` - ${todo.description}`;
+
+      if (todo.dependencies && todo.dependencies.length > 0) {
+        output += ` [deps: ${todo.dependencies.join(', ')}]`;
+      }
+      
+      if (todo.estimatedTime) {
+        output += ` ⏱️ ${todo.estimatedTime}`;
+      }
+      
+      output += '\n';
+
+      if (todo.risks && todo.risks.length > 0) {
+        output += `  ⚠️  ${todo.risks.join(', ')}\n`;
+      }
+    }
+    output += '\n';
+  }
+
+  // Show completed todos
+  const completed = todos.filter(t => t.status === 'completed');
+  if (completed.length > 0) {
+    output += `### ✅ Completed (${completed.length})\n\n`;
+    completed.forEach(t => {
+      output += `✅ \`${t.id}\` - ${t.description}\n`;
+    });
+    output += '\n';
+  }
+
+  // Show cancelled todos
+  const cancelled = todos.filter(t => t.status === 'cancelled');
+  if (cancelled.length > 0) {
+    output += `### ❌ Cancelled (${cancelled.length})\n\n`;
+    cancelled.forEach(t => {
+      output += `❌ \`${t.id}\` - ${t.description}\n`;
+    });
+  }
+
+  return output;
+}
+
+/**
+ * Get status icon for display
+ */
+function getStatusIcon(status: TodoStatus): string {
+  return {
+    pending: '⬜',
+    in_progress: '🔄',
+    completed: '✅',
+    cancelled: '❌',
+  }[status];
+}
+
+/**
+ * Convert plan to todos
+ */
+export function planToTodos(plan: PlanData): ExtendedTodo[] {
+  return plan.steps.map((step, idx) => ({
+    id: step.id,
+    description: step.description,
+    status: 'pending' as TodoStatus,
+    priority: (idx < 3 ? 'high' : idx < 6 ? 'medium' : 'low') as TodoPriority,
+    module: step.module,
+    dependencies: step.dependencies || [],
+    risks: step.risks || [],
+    estimatedTime: step.estimatedTime,
+    createdFrom: 'plan' as const,
+    createdAt: new Date(),
+  }));
+}
+
+/**
+ * Check if todo's dependencies are satisfied
+ */
+export function checkDependencies(
+  todo: ExtendedTodo,
+  allTodos: ExtendedTodo[],
+): { satisfied: boolean; incomplete: string[] } {
+  if (!todo.dependencies || todo.dependencies.length === 0) {
+    return { satisfied: true, incomplete: [] };
+  }
+
+  const incomplete: string[] = [];
+
+  for (const depId of todo.dependencies) {
+    const dep = allTodos.find(t => t.id === depId);
+    if (!dep || dep.status !== 'completed') {
+      incomplete.push(depId);
+    }
+  }
+
+  return {
+    satisfied: incomplete.length === 0,
+    incomplete,
+  };
+}
+
+/**
+ * Get next executable todo (considering dependencies)
+ */
+export function getNextExecutableTodo(todos: ExtendedTodo[]): ExtendedTodo | null {
+  const pending = todos.filter(t => t.status === 'pending');
+
+  for (const todo of pending) {
+    const { satisfied } = checkDependencies(todo, todos);
+    if (satisfied) {
+      return todo;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Export todos to JSON format
+ */
+export function exportTodosToJson(
+  todos: ExtendedTodo[],
+  plan: PlanData | null,
+): string {
+  const stats = {
+    total: todos.length,
+    pending: todos.filter(t => t.status === 'pending').length,
+    in_progress: todos.filter(t => t.status === 'in_progress').length,
+    completed: todos.filter(t => t.status === 'completed').length,
+    cancelled: todos.filter(t => t.status === 'cancelled').length,
+  };
+
+  const exportData = {
+    version: '1.0',
+    generatedAt: new Date().toISOString(),
+    sourcePlan: plan?.title || null,
+    todos,
+    statistics: stats,
+  };
+
+  return JSON.stringify(exportData, null, 2);
+}
+
+

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -34,6 +34,7 @@ import { WebFetchTool } from '../tools/web-fetch.js';
 import { ReadManyFilesTool } from '../tools/read-many-files.js';
 import { MemoryTool, setGeminiMdFilename } from '../tools/memoryTool.js';
 import { WebSearchTool } from '../tools/web-search.js';
+import { CreatePlanTool } from '../tools/create-plan.js';
 import { GeminiClient } from '../core/client.js';
 import { BaseLlmClient } from '../core/baseLlmClient.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
@@ -1361,6 +1362,7 @@ export class Config {
     registerCoreTool(ShellTool, this);
     registerCoreTool(MemoryTool);
     registerCoreTool(WebSearchTool, this);
+    registerCoreTool(CreatePlanTool);
 
     await registry.discoverAllTools();
     return registry;

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -362,6 +362,101 @@ Your core function is efficient and safe assistance. Balance extreme conciseness
 }
 
 /**
+ * Get system prompt for Plan mode (read-only planning)
+ */
+export function getPlanModeSystemPrompt(): string {
+  return `
+# 🎯 PLAN MODE - Structured Planning Only
+
+You are in **PLAN MODE**. Your goal is to analyze requirements and create detailed execution plans, NOT to execute them.
+
+## Constraints
+
+✅ **YOU CAN:**
+- Read files (read_file, read_many_files)
+- Search codebase (grep, rg, glob, ls)
+- Research information (web_search, web_fetch)
+- **Create structured plan (create_plan)** ⭐
+
+❌ **YOU CANNOT:**
+- Write or edit files (edit, write_file, smart_edit)
+- Execute commands (bash, shell)
+- Make any changes to the codebase
+- Use write_todos (use create_plan instead)
+
+## Your Workflow
+
+1. **Understand**: Read relevant files, search for patterns, understand the codebase
+2. **Analyze**: Identify what needs to be done, dependencies, risks
+3. **Plan**: Call the \`create_plan\` tool with structured output
+
+## create_plan Tool Requirements
+
+You MUST call the \`create_plan\` tool with this structure:
+
+\`\`\`json
+{
+  "title": "Brief descriptive title (e.g., 'Implement User Authentication')",
+  "overview": "1-2 sentence summary of the goal",
+  "steps": [
+    {
+      "id": "step-1",  // Unique ID
+      "description": "Clear, actionable task (e.g., 'Create User model with email and password fields')",
+      "module": "backend/models",  // Optional: which part of codebase
+      "dependencies": [],  // Optional: IDs of steps this depends on
+      "risks": ["Database migration might fail"],  // Optional: specific risks
+      "estimatedTime": "30min"  // Optional: time estimate
+    },
+    {
+      "id": "step-2",
+      "description": "Implement JWT token generation and validation logic",
+      "module": "backend/auth",
+      "dependencies": ["step-1"],  // Depends on step-1
+      "risks": ["Token security vulnerabilities", "Key rotation issues"],
+      "estimatedTime": "45min"
+    }
+  ],
+  "risks": [  // Optional: overall project-level risks
+    "Password hashing performance issues",
+    "Session management complexity"
+  ],
+  "testingStrategy": "Unit tests for User model, JWT utils. Integration tests for login/logout flow.",
+  "estimatedDuration": "3-4 hours"  // Optional: total estimate
+}
+\`\`\`
+
+## Best Practices
+
+1. **Steps should be:**
+   - Actionable and specific
+   - Properly ordered with dependencies
+   - Include module/component context
+   - Estimate realistic timeframes
+
+2. **Identify risks for:**
+   - Each complex step
+   - Overall project challenges
+   - Integration points
+   - Security concerns
+
+3. **Testing strategy should cover:**
+   - What to test at each step
+   - Test types (unit, integration, e2e)
+   - Verification approach
+
+## After You Create the Plan
+
+The user will:
+1. Review your plan
+2. Exit Plan mode (Ctrl+P)
+3. Convert to executable todos: \`/plan to-todos\`
+4. Execute todos step-by-step: \`/todos execute <id>\`
+
+Focus on **thorough analysis** and **clear, actionable steps**. Do NOT try to execute anything.
+`;
+}
+
+/**
  * Provides the system prompt for the history compression process.
  * This prompt instructs the model to act as a specialized state manager,
  * think in a scratchpad, and produce a structured XML summary.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -144,6 +144,7 @@ export * from './tools/read-many-files.js';
 export * from './tools/mcp-client.js';
 export * from './tools/mcp-tool.js';
 export * from './tools/write-todos.js';
+export * from './tools/create-plan.js';
 
 // MCP OAuth
 export { MCPOAuthProvider } from './mcp/oauth-provider.js';

--- a/packages/core/src/tools/create-plan.ts
+++ b/packages/core/src/tools/create-plan.ts
@@ -1,0 +1,281 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ToolInvocation } from './tools.js';
+import {
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+  type ToolResult,
+} from './tools.js';
+
+/**
+ * A single step in an execution plan
+ */
+export interface PlanStep {
+  id: string;
+  description: string;
+  module?: string;
+  dependencies?: string[];
+  risks?: string[];
+  estimatedTime?: string;
+}
+
+/**
+ * Parameters for the create_plan tool
+ */
+export interface PlanToolParams {
+  title: string;
+  overview: string;
+  steps: PlanStep[];
+  risks?: string[];
+  testingStrategy?: string;
+  estimatedDuration?: string;
+}
+
+export const CREATE_PLAN_TOOL_NAME = 'create_plan';
+
+export const CREATE_PLAN_DESCRIPTION = `Create a structured execution plan with steps, risks, and testing strategy.
+
+This tool should be used when:
+- Complex tasks requiring multiple steps
+- Tasks that need risk analysis  
+- When user explicitly requests planning
+- In PLAN MODE (Ctrl+P)
+
+REQUIRED FIELDS:
+- title: Brief plan title
+- overview: 1-2 sentence summary of what will be accomplished
+- steps: Array of execution steps, each with:
+  - id: Unique identifier (e.g., "step-1", "setup-db")
+  - description: Clear, actionable task description
+  - dependencies: (Optional) Array of step IDs this depends on
+  - risks: (Optional) Potential issues for this step
+  - module: (Optional) Which module/component this affects
+  - estimatedTime: (Optional) Time estimate (e.g., "30min", "2h")
+
+OPTIONAL FIELDS:
+- risks: Overall project-level risks
+- testingStrategy: How to verify the implementation works
+- estimatedDuration: Total time estimate
+
+OUTPUT EXAMPLE:
+{
+  "title": "Implement User Authentication",
+  "overview": "Add JWT-based authentication with login/logout endpoints",
+  "steps": [
+    {
+      "id": "step-1",
+      "description": "Create User model and database schema",
+      "module": "backend/models",
+      "dependencies": [],
+      "risks": ["Database migration might fail in production"],
+      "estimatedTime": "30min"
+    },
+    {
+      "id": "step-2", 
+      "description": "Implement JWT token generation and validation",
+      "module": "backend/auth",
+      "dependencies": ["step-1"],
+      "risks": ["Token security vulnerabilities"],
+      "estimatedTime": "45min"
+    }
+  ],
+  "risks": [
+    "Password hashing performance issues",
+    "Session management complexity"
+  ],
+  "testingStrategy": "Unit tests for each component, integration tests for full auth flow",
+  "estimatedDuration": "3-4 hours"
+}
+
+IMPORTANT: In Plan mode, focus on thorough analysis and planning. Do NOT execute the plan.
+User will convert the plan to todos and execute them step by step.`;
+
+class CreatePlanToolInvocation extends BaseToolInvocation<
+  PlanToolParams,
+  ToolResult
+> {
+  getDescription(): string {
+    return `Create plan: ${this.params.title}`;
+  }
+
+  async execute(
+    _signal: AbortSignal,
+    _updateOutput?: (output: string) => void,
+  ): Promise<ToolResult> {
+    const plan = this.params;
+
+    // Build formatted output
+    let output = `✅ **Plan Created**: "${plan.title}"\n\n`;
+    output += `**Overview**: ${plan.overview}\n\n`;
+    output += `**Steps**: ${plan.steps.length}\n`;
+    
+    plan.steps.forEach((step, idx) => {
+      output += `\n${idx + 1}. **${step.id}**: ${step.description}`;
+      if (step.dependencies && step.dependencies.length > 0) {
+        output += `\n   - Dependencies: ${step.dependencies.join(', ')}`;
+      }
+      if (step.risks && step.risks.length > 0) {
+        output += `\n   - ⚠️ Risks: ${step.risks.join(', ')}`;
+      }
+      if (step.estimatedTime) {
+        output += `\n   - ⏱️ Estimated: ${step.estimatedTime}`;
+      }
+    });
+
+    if (plan.risks && plan.risks.length > 0) {
+      output += `\n\n**Overall Risks**:\n`;
+      plan.risks.forEach(r => output += `- ${r}\n`);
+    }
+
+    if (plan.testingStrategy) {
+      output += `\n**Testing Strategy**: ${plan.testingStrategy}\n`;
+    }
+
+    if (plan.estimatedDuration) {
+      output += `\n**Estimated Duration**: ${plan.estimatedDuration}\n`;
+    }
+
+    output += `\n💡 Next steps:\n`;
+    output += `1. Review the plan above\n`;
+    output += `2. Exit Plan mode: Ctrl+P\n`;
+    output += `3. Convert to todos: /plan to-todos\n`;
+    output += `4. Execute todos: /todos execute <id>\n`;
+
+    return {
+      llmContent: `Successfully created execution plan with ${plan.steps.length} steps. The plan is now available for review.`,
+      returnDisplay: output,
+    };
+  }
+}
+
+export class CreatePlanTool extends BaseDeclarativeTool<
+  PlanToolParams,
+  ToolResult
+> {
+  static readonly Name: string = CREATE_PLAN_TOOL_NAME;
+
+  constructor() {
+    super(
+      CreatePlanTool.Name,
+      'Create Execution Plan',
+      CREATE_PLAN_DESCRIPTION,
+      Kind.Other,
+      {
+        type: 'object',
+        properties: {
+          title: {
+            type: 'string',
+            description: 'Brief descriptive title of the plan',
+          },
+          overview: {
+            type: 'string',
+            description: '1-2 sentence summary of what will be accomplished',
+          },
+          steps: {
+            type: 'array',
+            description: 'Ordered list of execution steps',
+            items: {
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'string',
+                  description: 'Unique identifier for this step',
+                },
+                description: {
+                  type: 'string',
+                  description: 'Clear, actionable description of what to do',
+                },
+                module: {
+                  type: 'string',
+                  description: 'Optional: which module/component this affects',
+                },
+                dependencies: {
+                  type: 'array',
+                  description: 'Optional: IDs of steps this depends on',
+                  items: { type: 'string' },
+                },
+                risks: {
+                  type: 'array',
+                  description: 'Optional: potential issues for this step',
+                  items: { type: 'string' },
+                },
+                estimatedTime: {
+                  type: 'string',
+                  description: 'Optional: time estimate (e.g., "30min", "2h")',
+                },
+              },
+              required: ['id', 'description'],
+            },
+          },
+          risks: {
+            type: 'array',
+            description: 'Optional: overall project-level risks',
+            items: { type: 'string' },
+          },
+          testingStrategy: {
+            type: 'string',
+            description: 'Optional: how to verify the implementation',
+          },
+          estimatedDuration: {
+            type: 'string',
+            description: 'Optional: total time estimate',
+          },
+        },
+        required: ['title', 'overview', 'steps'],
+      },
+    );
+  }
+
+  protected override validateToolParamValues(
+    params: PlanToolParams,
+  ): string | null {
+    if (!params || typeof params !== 'object') {
+      return 'Plan parameters must be an object';
+    }
+
+    if (!params.title || typeof params.title !== 'string') {
+      return 'Plan must have a title';
+    }
+
+    if (!params.overview || typeof params.overview !== 'string') {
+      return 'Plan must have an overview';
+    }
+
+    if (!Array.isArray(params.steps) || params.steps.length === 0) {
+      return 'Plan must have at least one step';
+    }
+
+    for (const step of params.steps) {
+      if (!step.id || typeof step.id !== 'string') {
+        return 'Each step must have an id';
+      }
+      if (!step.description || typeof step.description !== 'string') {
+        return 'Each step must have a description';
+      }
+
+      // Validate dependencies reference valid step IDs
+      if (step.dependencies && Array.isArray(step.dependencies)) {
+        const allStepIds = params.steps.map(s => s.id);
+        for (const depId of step.dependencies) {
+          if (!allStepIds.includes(depId)) {
+            return `Step ${step.id} has invalid dependency: ${depId}`;
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  protected createInvocation(
+    params: PlanToolParams,
+  ): ToolInvocation<PlanToolParams, ToolResult> {
+    return new CreatePlanToolInvocation(params);
+  }
+}
+

--- a/packages/core/src/tools/write-todos.ts
+++ b/packages/core/src/tools/write-todos.ts
@@ -80,10 +80,29 @@ The agent did not use the todo list because this task could be completed by a ti
 `;
 
 export type TodoStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled';
+export type TodoPriority = 'high' | 'medium' | 'low';
 
 export interface Todo {
   description: string;
   status: TodoStatus;
+}
+
+/**
+ * Extended Todo interface for Plan+Todo mode
+ * Includes additional metadata for better task management
+ */
+export interface ExtendedTodo {
+  id: string;
+  description: string;
+  status: TodoStatus;
+  priority: TodoPriority;
+  module?: string;
+  dependencies?: string[];
+  risks?: string[];
+  estimatedTime?: string;
+  createdFrom?: 'plan' | 'manual';
+  createdAt?: Date;
+  completedAt?: Date;
 }
 
 export interface WriteTodosToolParams {


### PR DESCRIPTION
✨ 新功能
- Plan 模式：Ctrl+P 触发只读规划模式
- create_plan 工具：结构化计划输出
- Todo 管理：内存存储，状态管理，依赖检查
- /plan 命令组：show, to-todos, clear
- /todos 命令组：list, execute, execute-all, update, export, clear
- 批量执行：/todos execute-all 自动执行所有待办
- 执行模式：default（安全）和 auto_edit（快速）

🏗️ 核心实现
- ExtendedTodo 接口：优先级、依赖、风险、时间估计
- Plan 模式系统提示词注入
- 工具过滤：Plan 模式下只允许只读工具
- 状态管理：React hooks + useRef 避免闭包陷阱
- 批量执行队列：自动续接、中断处理、错误恢复

🐛 Bug 修复
- API 错误：修复孤儿 tool 响应导致的 API 错误
- 闭包陷阱：使用 useRef 确保批量执行访问最新状态
- 依赖检查：严格验证依赖关系

📚 文档
- design/plan-todo/ 完整设计和实现文档
- docs/PLAN_TODO_MODE_USER_GUIDE.md 用户手册
- 更新 design/README.md 索引

🎯 状态：✅ 已完成并验证

